### PR TITLE
Fix scrolls modal hidden by keyboard on mobile

### DIFF
--- a/app/(tabs)/scrolls.tsx
+++ b/app/(tabs)/scrolls.tsx
@@ -3,7 +3,9 @@ import { useCallback, useState } from 'react';
 import { useFocusEffect, useRouter } from 'expo-router';
 import {
   ActivityIndicator,
+  KeyboardAvoidingView,
   Modal,
+  Platform,
   SafeAreaView,
   ScrollView,
   StyleSheet,
@@ -155,6 +157,10 @@ export default function ScrollsTab() {
         animationType="slide"
         onRequestClose={() => setShowModal(false)}
       >
+        <KeyboardAvoidingView
+          style={{ flex: 1 }}
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        >
         <TouchableWithoutFeedback onPress={() => setShowModal(false)}>
           <View style={styles.modalOverlay}>
             <TouchableWithoutFeedback>
@@ -195,6 +201,7 @@ export default function ScrollsTab() {
             </TouchableWithoutFeedback>
           </View>
         </TouchableWithoutFeedback>
+        </KeyboardAvoidingView>
       </Modal>
     </SafeAreaView>
   );


### PR DESCRIPTION
Wrap the Request a Scroll bottom sheet in KeyboardAvoidingView so the text input and submit button remain visible when the keyboard opens.