### PR TITLE
fix: use local date in today() helper to prevent UTC timezone offset

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -24,7 +24,8 @@ async function getUserId(): Promise<string | null> {
 }
 
 function today(): string {
-  return new Date().toISOString().split('T')[0]
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
 }
 
 // ----------------------------------------------------------------


### PR DESCRIPTION
Replaces toISOString().split('T')[0] with local date construction so daily reset triggers at midnight device-local time instead of 8pm Eastern.