### PR TITLE
feat: redesign home screen as daily dashboard

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -12,6 +12,13 @@ function getGreeting(): string {
   return 'Good evening';
 }
 
+function getPrimaryCTA(): { label: string; route: string } {
+  const hour = new Date().getHours();
+  if (hour < 12) return { label: 'Begin Morning Routine', route: '/morning' };
+  if (hour < 17) return { label: 'Open the Cabinet', route: '/cabinet' };
+  return { label: 'Evening Reflection', route: '/evening' };
+}
+
 const DEFAULT_CABINET_SLUGS = ['marcus-aurelius', 'epictetus', 'david-goggins', 'theodore-roosevelt'];
 
 export default function HomeScreen() {
@@ -63,10 +70,12 @@ export default function HomeScreen() {
     }
   };
 
+  const cta = getPrimaryCTA();
+
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content} {...swipeHandlers}>
 
-      {/* Top Bar with Settings */}
+      {/* Top Bar */}
       <View style={styles.topBar}>
         <View>
           <Text style={styles.greeting}>{getGreeting()}, {userName.split(' ')[0]}</Text>
@@ -80,25 +89,20 @@ export default function HomeScreen() {
         </TouchableOpacity>
       </View>
 
-      {/* Daily Quote */}
-      {quote && (
-      <View style={styles.quoteContainer}>
-        <Ionicons name="flame-outline" size={20} color="#c9a84c" />
-        <View style={{ flex: 1 }}>
-          <Text style={styles.quote}>"{quote.text}"</Text>
-          <Text style={styles.quoteAttribution}>— {quote.author}</Text>
+      {/* Quote Card */}
+      {quote ? (
+        <View style={styles.quoteCard}>
+          <Text style={styles.quoteGlyph}>"</Text>
+          <View style={styles.quoteBody}>
+            <Text style={styles.quoteText}>{quote.text}</Text>
+            <Text style={styles.quoteAuthor}>— {quote.author}</Text>
+          </View>
         </View>
-      </View>
+      ) : (
+        <View style={styles.quoteSkeleton} />
       )}
 
-      {/* Streak */}
-      <View style={styles.streakContainer}>
-        <Ionicons name="trophy-outline" size={28} color="#c9a84c" />
-        <Text style={styles.streakNumber}>{streak}</Text>
-        <Text style={styles.streakLabel}>Days of Discipline 🕯️</Text>
-      </View>
-
-      {/* Know Thyself Incomplete Banner */}
+      {/* Know Thyself Banner */}
       {knowThyselfIncomplete && (
         <View style={styles.ktBanner}>
           <View style={styles.ktBannerHeader}>
@@ -114,25 +118,50 @@ export default function HomeScreen() {
         </View>
       )}
 
-      {/* Today's Progress */}
-      <TouchableOpacity onPress={() => router.push('/progress')}>
-        <Text style={styles.sectionTitle}>Today's Disciplines</Text>
+      {/* Status Pills */}
+      <View style={styles.pillRow}>
+        <TouchableOpacity
+          style={[styles.pill, morningDone && styles.pillActive]}
+          onPress={() => router.push('/morning' as any)}
+        >
+          <Text style={styles.pillEmoji}>☀️</Text>
+          <Text style={[styles.pillLabel, morningDone && styles.pillLabelActive]}>Morning</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.pill, styles.pillActive]}
+          onPress={() => router.push('/cabinet' as any)}
+        >
+          <Text style={styles.pillEmoji}>🏛️</Text>
+          <Text style={[styles.pillLabel, styles.pillLabelActive]}>Cabinet</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.pill, eveningDone && styles.pillActive]}
+          onPress={() => router.push('/evening' as any)}
+        >
+          <Text style={styles.pillEmoji}>🌙</Text>
+          <Text style={[styles.pillLabel, eveningDone && styles.pillLabelActive]}>Evening</Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* Primary CTA */}
+      <TouchableOpacity
+        style={styles.ctaButton}
+        onPress={() => router.push(cta.route as any)}
+      >
+        <Text style={styles.ctaLabel}>{cta.label}</Text>
+        <Ionicons name="arrow-forward" size={18} color="#1a1a2e" />
       </TouchableOpacity>
-      <View style={styles.progressContainer}>
-        <TouchableOpacity style={[styles.progressCard, morningDone && styles.progressCardDone]} onPress={() => router.push('/morning')}>
-          <Ionicons name="sunny-outline" size={24} color={morningDone ? '#1a1a2e' : '#c9a84c'} />
-          <Text style={[styles.progressText, morningDone && styles.progressTextDone]}>
-            Morning Routine
-          </Text>
-          {morningDone && <Ionicons name="checkmark-circle" size={20} color="#1a1a2e" />}
-        </TouchableOpacity>
-        <TouchableOpacity style={[styles.progressCard, eveningDone && styles.progressCardDone]} onPress={() => router.push('/evening')}>
-          <Ionicons name="moon-outline" size={24} color={eveningDone ? '#1a1a2e' : '#c9a84c'} />
-          <Text style={[styles.progressText, eveningDone && styles.progressTextDone]}>
-            Evening Routine
-          </Text>
-          {eveningDone && <Ionicons name="checkmark-circle" size={20} color="#1a1a2e" />}
-        </TouchableOpacity>
+
+      {/* Streak Card */}
+      <View style={styles.streakCard}>
+        <Text style={styles.streakCount}>{streak}</Text>
+        <View style={styles.streakMeta}>
+          <Text style={styles.streakLabel}>Days of Discipline</Text>
+          <Text style={styles.streakSub}>Keep the chain unbroken.</Text>
+        </View>
+        <Ionicons name="flame" size={32} color="#c9a84c" />
       </View>
 
     </ScrollView>
@@ -159,12 +188,6 @@ const styles = StyleSheet.create({
     fontSize: 20,
     color: '#888',
   },
-  greetingSubtitle: {
-    fontSize: 13,
-    color: '#c9a84c',
-    fontStyle: 'italic',
-    marginTop: 2,
-  },
   name: {
     fontSize: 32,
     fontWeight: 'bold',
@@ -178,84 +201,50 @@ const styles = StyleSheet.create({
     borderColor: '#c9a84c33',
     marginTop: 5,
   },
-  quoteContainer: {
+  quoteCard: {
     backgroundColor: '#16213e',
-    borderRadius: 12,
-    padding: 20,
-    marginBottom: 25,
+    borderRadius: 14,
     borderLeftWidth: 3,
     borderLeftColor: '#c9a84c',
+    padding: 20,
+    marginBottom: 20,
     flexDirection: 'row',
-    alignItems: 'flex-start',
-    gap: 10,
+    gap: 12,
   },
-  quote: {
+  quoteGlyph: {
+    fontSize: 44,
+    lineHeight: 44,
     color: '#c9a84c',
+    fontWeight: 'bold',
+    marginTop: -4,
+  },
+  quoteBody: {
+    flex: 1,
+  },
+  quoteText: {
+    color: '#e8e0d0',
     fontSize: 14,
     fontStyle: 'italic',
     lineHeight: 22,
   },
-  quoteAttribution: {
-    color: '#888',
-    fontSize: 12,
-    fontStyle: 'italic',
-    marginTop: 6,
-  },
-  streakContainer: {
-    backgroundColor: '#16213e',
-    borderRadius: 12,
-    padding: 20,
-    marginBottom: 25,
-    alignItems: 'center',
-    flexDirection: 'row',
-    gap: 10,
-  },
-  streakNumber: {
-    fontSize: 36,
-    fontWeight: 'bold',
+  quoteAuthor: {
     color: '#c9a84c',
+    fontSize: 12,
+    marginTop: 8,
+    fontWeight: '600',
   },
-  streakLabel: {
-    fontSize: 16,
-    color: '#fff',
-  },
-  sectionTitle: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    color: '#fff',
-    marginBottom: 15,
-  },
-  progressContainer: {
-    gap: 12,
-    marginBottom: 25,
-  },
-  progressCard: {
+  quoteSkeleton: {
     backgroundColor: '#16213e',
-    borderRadius: 12,
-    padding: 18,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-    borderWidth: 1,
-    borderColor: '#c9a84c33',
-  },
-  progressCardDone: {
-    backgroundColor: '#c9a84c',
-  },
-  progressText: {
-    color: '#fff',
-    fontSize: 16,
-    flex: 1,
-  },
-  progressTextDone: {
-    color: '#1a1a2e',
-    fontWeight: 'bold',
+    borderRadius: 14,
+    height: 90,
+    marginBottom: 20,
+    opacity: 0.4,
   },
   ktBanner: {
     backgroundColor: '#16213e',
     borderRadius: 12,
     padding: 18,
-    marginBottom: 25,
+    marginBottom: 20,
     borderWidth: 1,
     borderColor: '#c9a84c',
   },
@@ -280,5 +269,84 @@ const styles = StyleSheet.create({
     color: '#c9a84c',
     fontSize: 14,
     fontWeight: '600',
+  },
+  pillRow: {
+    flexDirection: 'row',
+    gap: 10,
+    marginBottom: 20,
+  },
+  pill: {
+    flex: 1,
+    backgroundColor: '#16213e',
+    borderRadius: 50,
+    paddingVertical: 13,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: '#2a2a3e',
+    gap: 4,
+  },
+  pillActive: {
+    backgroundColor: '#c9a84c18',
+    borderColor: '#c9a84c',
+  },
+  pillEmoji: {
+    fontSize: 18,
+  },
+  pillLabel: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: '#444',
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+  },
+  pillLabelActive: {
+    color: '#c9a84c',
+  },
+  ctaButton: {
+    backgroundColor: '#c9a84c',
+    borderRadius: 14,
+    paddingVertical: 18,
+    paddingHorizontal: 24,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    marginBottom: 20,
+  },
+  ctaLabel: {
+    color: '#1a1a2e',
+    fontSize: 17,
+    fontWeight: '700',
+    letterSpacing: 0.2,
+  },
+  streakCard: {
+    backgroundColor: '#16213e',
+    borderRadius: 14,
+    padding: 24,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+    borderWidth: 1,
+    borderColor: '#c9a84c33',
+  },
+  streakCount: {
+    fontSize: 52,
+    fontWeight: 'bold',
+    color: '#c9a84c',
+    lineHeight: 56,
+  },
+  streakMeta: {
+    flex: 1,
+  },
+  streakLabel: {
+    fontSize: 16,
+    color: '#fff',
+    fontWeight: '600',
+  },
+  streakSub: {
+    fontSize: 12,
+    color: '#666',
+    marginTop: 3,
+    fontStyle: 'italic',
   },
 });


### PR DESCRIPTION
- Replace resource feed + discipline cards with status pills, CTA button, and streak card
- Three tappable pills (Morning, Cabinet, Evening) show completion state in gold
- Time-aware primary CTA routes to morning/cabinet/evening by hour
- Quote card with gold left border and glyph; skeleton placeholder while loading
- Streak card with large count, label, and flame icon
- No data loading changes — purely UI restructure