### PR TITLE
feat(academy): interactive framework page

### DIFF
--- a/academy/web/src/app/framework/framework.module.css
+++ b/academy/web/src/app/framework/framework.module.css
@@ -1,0 +1,897 @@
+/* ── Base ──────────────────────────────────────────────────────────────────── */
+
+.page {
+  background: #0a1628;
+  color: #e0d4b8;
+  min-height: 100vh;
+  font-family: Georgia, 'Times New Roman', serif;
+}
+
+/* ── Hero ─────────────────────────────────────────────────────────────────── */
+
+.hero {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 80px 32px 60px;
+  text-align: center;
+}
+
+.heroEyebrow {
+  font-size: 10px;
+  letter-spacing: 5px;
+  color: #c9a84c;
+  opacity: 0.7;
+  margin-bottom: 24px;
+  font-family: Georgia, serif;
+}
+
+.heroTitle {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0 0 24px;
+}
+
+.heroGreek {
+  font-size: clamp(28px, 5vw, 52px);
+  font-weight: bold;
+  color: #e8d5a0;
+  letter-spacing: 2px;
+  line-height: 1.1;
+}
+
+.heroEng {
+  font-size: clamp(14px, 2vw, 18px);
+  color: #c9a84c;
+  letter-spacing: 4px;
+  font-weight: normal;
+  opacity: 0.8;
+}
+
+.heroSub {
+  color: #8a9ab0;
+  font-size: 15px;
+  line-height: 1.7;
+  max-width: 540px;
+  margin: 0 auto 32px;
+  font-style: italic;
+}
+
+.heroRule {
+  width: 200px;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, #c9a84c, transparent);
+  margin: 0 auto 40px;
+  opacity: 0.5;
+}
+
+/* ── Scale Bar ────────────────────────────────────────────────────────────── */
+
+.scaleWrap {
+  margin: 0 auto 40px;
+  max-width: 900px;
+}
+
+.scaleBar {
+  display: flex;
+  height: 40px;
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid rgba(201, 168, 76, 0.2);
+  margin-bottom: 12px;
+}
+
+.scaleSegment {
+  flex: 1;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.25s, flex 0.3s;
+  position: relative;
+}
+
+.scaleSegment:first-child {
+  background: linear-gradient(90deg, rgba(201,168,76,0.35), rgba(201,168,76,0.1));
+}
+.scaleSegment:nth-child(2) {
+  background: linear-gradient(90deg, rgba(138,122,58,0.2), rgba(138,122,58,0.15));
+}
+.scaleSegment:nth-child(3) {
+  background: rgba(30, 58, 74, 0.3);
+}
+.scaleSegment:nth-child(4) {
+  background: linear-gradient(90deg, rgba(106,58,42,0.15), rgba(106,58,42,0.25));
+}
+.scaleSegment:last-child {
+  background: linear-gradient(90deg, rgba(139,32,32,0.2), rgba(139,32,32,0.4));
+}
+
+.scaleSegment:hover,
+.scaleSegmentActive {
+  flex: 2;
+}
+
+.scaleSegmentActive {
+  background: rgba(var(--zone-color-rgb, 201,168,76), 0.2) !important;
+  outline: 1px solid var(--zone-color);
+}
+
+.scaleGreek {
+  font-size: 8px;
+  letter-spacing: 1px;
+  color: var(--zone-color);
+  opacity: 0;
+  transition: opacity 0.2s;
+  white-space: nowrap;
+}
+
+.scaleSegment:hover .scaleGreek,
+.scaleSegmentActive .scaleGreek {
+  opacity: 1;
+}
+
+.scaleLabels {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.scaleLabel {
+  flex: 1;
+  background: none;
+  border: none;
+  font-size: 10px;
+  color: #666;
+  cursor: pointer;
+  text-align: center;
+  font-family: Georgia, serif;
+  letter-spacing: 0.5px;
+  padding: 4px 2px;
+  transition: color 0.2s;
+}
+
+.scaleLabel:hover,
+.scaleLabelActive {
+  color: var(--zone-color);
+}
+
+.scaleDirections {
+  display: flex;
+  justify-content: space-between;
+  font-size: 9px;
+  letter-spacing: 2px;
+  opacity: 0.6;
+  padding: 0 4px;
+  font-style: italic;
+}
+
+/* ── Hero Nav ─────────────────────────────────────────────────────────────── */
+
+.heroNav {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+
+.heroNavBtn {
+  background: none;
+  border: 1px solid rgba(201, 168, 76, 0.25);
+  color: #c9a84c;
+  padding: 8px 20px;
+  font-size: 11px;
+  letter-spacing: 1.5px;
+  cursor: pointer;
+  font-family: Georgia, serif;
+  transition: background 0.2s, border-color 0.2s;
+  border-radius: 2px;
+}
+
+.heroNavBtn:hover {
+  background: rgba(201, 168, 76, 0.08);
+  border-color: rgba(201, 168, 76, 0.6);
+}
+
+/* ── Section ──────────────────────────────────────────────────────────────── */
+
+.section {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 64px 32px;
+  border-top: 1px solid rgba(201, 168, 76, 0.15);
+}
+
+.sectionHeader {
+  margin-bottom: 40px;
+}
+
+.sectionNum {
+  font-size: 11px;
+  letter-spacing: 4px;
+  color: #c9a84c;
+  opacity: 0.5;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.sectionTitle {
+  font-size: clamp(22px, 3vw, 32px);
+  color: #e8d5a0;
+  font-weight: bold;
+  letter-spacing: 1px;
+  margin: 0 0 12px;
+}
+
+.sectionDesc {
+  color: #7a8a9a;
+  font-size: 14px;
+  font-style: italic;
+  line-height: 1.6;
+  max-width: 600px;
+  margin: 0;
+}
+
+/* ── Zone Grid ────────────────────────────────────────────────────────────── */
+
+.zoneGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 16px;
+}
+
+/* ── Zone Card ────────────────────────────────────────────────────────────── */
+
+.zoneCard {
+  background: var(--zone-bg);
+  border: 1px solid rgba(138, 122, 58, 0.3);
+  border-radius: 6px;
+  overflow: hidden;
+  transition: border-color 0.3s, box-shadow 0.3s, transform 0.25s;
+}
+
+.zoneCard:hover {
+  border-color: var(--zone-border);
+  transform: translateY(-2px);
+}
+
+.zoneCardActive {
+  border-color: var(--zone-color) !important;
+  box-shadow: 0 0 20px rgba(0,0,0,0.4), 0 0 0 1px var(--zone-color);
+}
+
+.zoneHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 20px 20px 16px;
+  border-bottom: 1px solid rgba(255,255,255,0.05);
+  background: rgba(0,0,0,0.2);
+}
+
+.zoneGreek {
+  font-size: 11px;
+  letter-spacing: 2px;
+  color: var(--zone-color);
+  margin-bottom: 4px;
+  opacity: 0.9;
+}
+
+.zoneLabel {
+  font-size: 16px;
+  font-weight: bold;
+  color: var(--zone-color);
+  margin-bottom: 2px;
+}
+
+.zoneSub {
+  font-size: 11px;
+  color: #666;
+  font-style: italic;
+}
+
+.zoneGreekTerm {
+  font-size: 9px;
+  color: #555;
+  font-style: italic;
+  text-align: right;
+  margin-top: 4px;
+}
+
+.zoneBody {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.zoneSection {}
+
+.zoneSectionLabel {
+  font-size: 8px;
+  letter-spacing: 2.5px;
+  color: var(--zone-color);
+  opacity: 0.7;
+  margin-bottom: 6px;
+}
+
+.zoneSectionText {
+  font-size: 13px;
+  color: #bbb;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.zoneList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.zoneList li {
+  font-size: 12.5px;
+  color: #bbb;
+  padding-left: 12px;
+  position: relative;
+  line-height: 1.4;
+}
+
+.zoneList li::before {
+  content: '·';
+  position: absolute;
+  left: 0;
+  color: var(--zone-color);
+  opacity: 0.6;
+}
+
+.zoneDrift {
+  font-size: 12.5px;
+  color: #888;
+  font-style: italic;
+  margin: 0;
+  line-height: 1.5;
+  border-left: 2px solid rgba(255,80,80,0.2);
+  padding-left: 10px;
+}
+
+.zoneQuote {
+  margin: 0;
+  padding: 12px 14px;
+  background: rgba(0,0,0,0.2);
+  border-radius: 3px;
+  border-left: 2px solid var(--zone-color);
+}
+
+.zoneQuote p {
+  font-size: 12px;
+  font-style: italic;
+  color: var(--zone-color);
+  margin: 0 0 6px;
+  line-height: 1.5;
+  opacity: 0.85;
+}
+
+.zoneQuote cite {
+  font-size: 10px;
+  color: #555;
+  font-style: normal;
+}
+
+/* ── Philosopher Map ──────────────────────────────────────────────────────── */
+
+.philWrap {
+  padding: 60px 0 20px;
+  position: relative;
+}
+
+.philBar {
+  position: relative;
+  height: 80px;
+}
+
+.philLine {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, #c9a84c, #1e3a4a 50%, #8b2020);
+  opacity: 0.4;
+}
+
+.philMarker {
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  cursor: pointer;
+}
+
+.philDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--phil-color);
+  border: 2px solid rgba(0,0,0,0.4);
+  transition: transform 0.2s;
+  position: relative;
+  z-index: 2;
+}
+
+.philMarker:hover .philDot {
+  transform: scale(1.5);
+}
+
+.philTick {
+  width: 1px;
+  height: 14px;
+  background: var(--phil-color);
+  margin: 0 auto;
+  opacity: 0.5;
+}
+
+.philName {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  font-size: 9px;
+  color: var(--phil-color);
+  letter-spacing: 0.5px;
+}
+
+.philNameAbove {
+  bottom: calc(100% + 18px);
+}
+
+.philNameBelow {
+  top: calc(100% + 18px);
+}
+
+.philTooltip {
+  position: absolute;
+  bottom: calc(100% + 36px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: #0d1628;
+  border: 1px solid var(--phil-color);
+  border-radius: 4px;
+  padding: 10px 14px;
+  width: 200px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+  z-index: 10;
+}
+
+.philTooltipVisible {
+  opacity: 1;
+}
+
+.philTooltip strong {
+  display: block;
+  color: var(--phil-color);
+  font-size: 11px;
+  margin-bottom: 4px;
+  letter-spacing: 0.5px;
+}
+
+.philTooltip span {
+  font-size: 11px;
+  color: #aaa;
+  line-height: 1.4;
+}
+
+.philCards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 12px;
+  margin-top: 32px;
+}
+
+.philCard {
+  background: rgba(255,255,255,0.02);
+  border: 1px solid rgba(255,255,255,0.06);
+  border-radius: 4px;
+  padding: 16px;
+  transition: border-color 0.2s;
+}
+
+.philCard:hover {
+  border-color: var(--phil-color);
+}
+
+.philCardName {
+  font-size: 12px;
+  font-weight: bold;
+  color: var(--phil-color);
+  margin-bottom: 6px;
+  letter-spacing: 0.5px;
+}
+
+.philCardDesc {
+  font-size: 11.5px;
+  color: #888;
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* ── Diagnostic ───────────────────────────────────────────────────────────── */
+
+.diagGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 16px;
+}
+
+.diagCard {
+  background: rgba(13, 24, 48, 0.8);
+  border: 1px solid rgba(58, 90, 110, 0.4);
+  border-radius: 5px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.diagNumber {
+  font-size: 9px;
+  letter-spacing: 3px;
+  color: #c9a84c;
+  opacity: 0.5;
+}
+
+.diagLabel {
+  font-size: 12px;
+  letter-spacing: 1.5px;
+  color: #7a9ab0;
+  font-weight: bold;
+}
+
+.diagQuestion {
+  font-size: 14px;
+  color: #e0d4b8;
+  font-style: italic;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.diagButtons {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.diagBtn {
+  flex: 1;
+  padding: 8px;
+  font-size: 11px;
+  letter-spacing: 0.5px;
+  border-radius: 3px;
+  cursor: pointer;
+  font-family: Georgia, serif;
+  transition: background 0.2s, color 0.2s;
+  border: 1px solid;
+}
+
+.diagBtnNo {
+  background: rgba(139, 32, 32, 0.1);
+  border-color: rgba(139, 32, 32, 0.3);
+  color: #c05050;
+}
+
+.diagBtnNo:hover,
+.diagBtnNo.diagBtnActive {
+  background: rgba(139, 32, 32, 0.25);
+  border-color: #8b2020;
+}
+
+.diagBtnYes {
+  background: rgba(12, 26, 14, 0.6);
+  border-color: rgba(138, 122, 58, 0.3);
+  color: #a89060;
+}
+
+.diagBtnYes:hover,
+.diagBtnYes.diagBtnActive {
+  background: rgba(12, 26, 14, 0.9);
+  border-color: #8a7a3a;
+}
+
+.diagResult {
+  font-size: 12.5px;
+  line-height: 1.5;
+  padding: 10px 12px;
+  border-radius: 3px;
+  border-left: 2px solid;
+  animation: fadeIn 0.2s ease;
+}
+
+.diagResultYes {
+  background: rgba(12, 26, 14, 0.6);
+  border-color: #8a7a3a;
+  color: #a89060;
+}
+
+.diagResultNo {
+  background: rgba(26, 8, 8, 0.6);
+  border-color: #8b2020;
+  color: #c08060;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Obstacles ────────────────────────────────────────────────────────────── */
+
+.obstGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 40px;
+}
+
+.obstCard {
+  background: var(--obs-bg);
+  border: 1px solid var(--obs-border);
+  border-radius: 5px;
+  overflow: hidden;
+  transition: border-color 0.2s;
+  opacity: 0.85;
+}
+
+.obstCard:hover,
+.obstCardOpen {
+  opacity: 1;
+}
+
+.obstHeader {
+  width: 100%;
+  background: none;
+  border: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 24px;
+  cursor: pointer;
+  text-align: left;
+  gap: 16px;
+}
+
+.obstThinker {
+  font-size: 18px;
+  font-weight: bold;
+  color: var(--obs-color);
+  letter-spacing: 1px;
+  margin-bottom: 2px;
+}
+
+.obstTitle {
+  font-size: 13px;
+  color: #ccc;
+  margin-bottom: 2px;
+}
+
+.obstSub {
+  font-size: 11px;
+  color: #666;
+  font-style: italic;
+}
+
+.obstChevron {
+  font-size: 22px;
+  color: var(--obs-color);
+  opacity: 0.6;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.obstBody {
+  padding: 0 24px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  animation: fadeIn 0.2s ease;
+}
+
+.obstBody p {
+  font-size: 13.5px;
+  color: #bbb;
+  line-height: 1.7;
+  margin: 0;
+}
+
+.obstPull {
+  font-size: 13px;
+  color: #c05050;
+  padding: 10px 14px;
+  background: rgba(139,32,32,0.08);
+  border-left: 2px solid rgba(139,32,32,0.4);
+  border-radius: 0 3px 3px 0;
+  line-height: 1.5;
+}
+
+.obstPullLabel {
+  color: #c05050;
+  font-weight: bold;
+  margin-right: 4px;
+}
+
+.obstResist {
+  font-size: 13px;
+  color: var(--obs-color);
+  opacity: 0.85;
+}
+
+.obstResistLabel {
+  font-style: italic;
+  margin-right: 4px;
+  opacity: 0.7;
+}
+
+/* ── Master Obstacle ──────────────────────────────────────────────────────── */
+
+.masterObstacle {
+  background: rgba(13, 18, 32, 0.8);
+  border: 1px solid rgba(201, 168, 76, 0.2);
+  border-radius: 6px;
+  padding: 32px;
+}
+
+.masterTitle {
+  font-size: 20px;
+  color: #e8d5a0;
+  font-weight: bold;
+  letter-spacing: 1px;
+  margin: 0 0 8px;
+}
+
+.masterSub {
+  font-size: 13px;
+  color: #888;
+  font-style: italic;
+  margin: 0 0 24px;
+  line-height: 1.6;
+}
+
+.masterGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.masterGrid div strong {
+  display: block;
+  font-size: 12px;
+  letter-spacing: 1px;
+  color: #c9a84c;
+  margin-bottom: 8px;
+}
+
+.masterGrid div p {
+  font-size: 13px;
+  color: #888;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.masterGrid div p em {
+  color: #c9a84c;
+  font-style: italic;
+}
+
+/* ── Footer ───────────────────────────────────────────────────────────────── */
+
+.footer {
+  text-align: center;
+  padding: 60px 32px 80px;
+  border-top: 1px solid rgba(201, 168, 76, 0.1);
+}
+
+.footerRule {
+  width: 80px;
+  height: 1px;
+  background: #c9a84c;
+  margin: 0 auto 24px;
+  opacity: 0.3;
+}
+
+.footerGreek {
+  font-size: 18px;
+  color: #c9a84c;
+  font-style: italic;
+  letter-spacing: 2px;
+  margin-bottom: 6px;
+}
+
+.footerEng {
+  font-size: 10px;
+  letter-spacing: 4px;
+  color: #444;
+  margin-bottom: 32px;
+}
+
+.footerCta {
+  display: inline-block;
+  border: 1px solid rgba(201, 168, 76, 0.4);
+  color: #c9a84c;
+  padding: 12px 32px;
+  font-size: 12px;
+  letter-spacing: 2px;
+  text-decoration: none;
+  font-family: Georgia, serif;
+  border-radius: 2px;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.footerCta:hover {
+  background: rgba(201, 168, 76, 0.08);
+  border-color: #c9a84c;
+}
+
+/* ── Responsive ───────────────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .hero {
+    padding: 48px 20px 40px;
+  }
+
+  .section {
+    padding: 48px 20px;
+  }
+
+  .scaleGreek {
+    display: none;
+  }
+
+  .heroNav {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .zoneGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .diagGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .philCards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .masterGrid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .philCards {
+    grid-template-columns: 1fr;
+  }
+
+  .masterGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Reduced motion ───────────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .zoneCard,
+  .philDot,
+  .scaleSegment,
+  .diagResult,
+  .obstBody {
+    transition: none;
+    animation: none;
+  }
+}

--- a/academy/web/src/app/framework/page.tsx
+++ b/academy/web/src/app/framework/page.tsx
@@ -1,0 +1,510 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import styles from './framework.module.css'
+
+// ── Data ────────────────────────────────────────────────────────────────────
+
+const ZONES = [
+  {
+    id: 'ataraxia',
+    greek: 'ἈΤΑΡΑΞΊΑ',
+    label: 'Ataraxia',
+    sub: 'The Terminus',
+    color: '#c9a84c',
+    borderColor: '#c9a84c',
+    bg: '#0c1a0e',
+    position: 0,
+    howItFeels: 'Nothing disturbs you at the root. Events happen; you respond, not react. No residue.',
+    markers: [
+      'Sleep is deep and undisturbed',
+      'No craving between meals',
+      "Criticism doesn't sting",
+      'Comfort and discomfort feel equal',
+      "No envy of others' lives",
+      'Death contemplated calmly',
+    ],
+    driftWarning: 'Spiritual pride — believing you\'ve arrived is itself a disturbance. The sage has no contempt.',
+    strategies: [
+      'Maintain the practice even after progress',
+      'Teach others — the Socratic obligation',
+      'Return to voluntary hardship periodically',
+      'Journal daily to stay honest',
+    ],
+    quote: '"He is a wise man who does not grieve for the things which he has not, but rejoices for those which he has."',
+    quoteBy: 'Epictetus',
+    greekTerm: 'σοφός · the sage',
+  },
+  {
+    id: 'askesis',
+    greek: 'ἌΣΚΗΣΙΣ',
+    label: 'Voluntary Askēsis',
+    sub: 'The Path',
+    color: '#a89060',
+    borderColor: '#8a7a3a',
+    bg: '#0f1a0f',
+    position: 25,
+    howItFeels: 'Chosen difficulty. Hard in the moment, clean afterward. You elected this — that matters.',
+    markers: [
+      "Training when you don't feel like it",
+      'Fasting with equanimity',
+      'Cold exposure without complaint',
+      'Choosing discomfort over convenience deliberately',
+      'Practice feels meaningful, not merely painful',
+    ],
+    driftWarning: 'Performing askēsis for identity or status — Seneca\'s trap. The practice must be inward.',
+    strategies: [
+      'Entry: skip one meal weekly, cold shower finish',
+      'Intermediate: 24hr fast, hard training fasted',
+      'Advanced: 36hr fast + training, poverty practice',
+      'Build a weekly rhythm — hardship is a training cycle',
+    ],
+    quote: '"Set aside a number of days in which you shall be content with the scantiest and cheapest fare."',
+    quoteBy: 'Seneca, Letters XVIII',
+    greekTerm: 'πόνος · toil with purpose',
+  },
+  {
+    id: 'neutral',
+    greek: 'ΜΈΣΟΝ',
+    label: 'Neutral State',
+    sub: 'The Untested Middle',
+    color: '#7a9ab0',
+    borderColor: '#3a5a6e',
+    bg: '#0e1620',
+    position: 50,
+    howItFeels: 'Fine. Not bad, not great. Comfortable enough to stay, not sharp enough to push leftward.',
+    markers: [
+      'No strong cravings but also no real discipline',
+      'Skipping practice when inconvenient',
+      '"I could stop anytime" — but never testing it',
+      'Days feel full but not directed',
+    ],
+    driftWarning: 'This zone is deceptive. Comfort gravity always pulls right. Without practice, drift is certain.',
+    strategies: [
+      'Name what you actually depend on',
+      'Do one hard thing daily',
+      'Subtraction audit: remove one comfort for 30 days',
+      'Ask: what would I lose if this were taken away?',
+    ],
+    quote: '"Comfort is the enemy of achievement and the parent of weakness."',
+    quoteBy: 'Seneca',
+    greekTerm: 'ἀδιάφορα · indifferents',
+  },
+  {
+    id: 'hedonic',
+    greek: 'ἩΔΟΝΉ',
+    label: 'Hedonic Drift',
+    sub: 'Accumulating Want',
+    color: '#c08060',
+    borderColor: '#6a3a2a',
+    bg: '#1a1010',
+    position: 75,
+    howItFeels: 'Restless satisfaction. Each want met births a new one. The horizon always moves.',
+    markers: [
+      'Scrolling without intent',
+      'Eating past hunger',
+      'Upgrading what works fine',
+      "Comparing your life to others' curated highlights",
+      'Boredom with the ordinary',
+    ],
+    driftWarning: 'Mimetic desire — wanting what others have, not what you actually need. Girard\'s trap.',
+    strategies: [
+      '48hr no-screen fast',
+      'Name your mimetic model: whose life are you wanting?',
+      'Remove one comfort per week for a month',
+      'Return to basics: sleep, water, movement, silence',
+    ],
+    quote: '"Men are disturbed not by the things which happen, but by the opinions about things."',
+    quoteBy: 'Epictetus, Enchiridion',
+    greekTerm: 'πλεονεξία · always more',
+  },
+  {
+    id: 'epithumia',
+    greek: 'ἘΠΙΘΥΜΊΑ',
+    label: 'Epithumia',
+    sub: 'Soul in Chains',
+    color: '#c05050',
+    borderColor: '#8b2020',
+    bg: '#1a0808',
+    position: 100,
+    howItFeels: 'Chronic low-grade anxiety. Nothing is ever enough. Anger when denied. Identity tied to having.',
+    markers: [
+      'Irritable when routines are disrupted',
+      "Can't sit in silence",
+      'Suffering when deprived of small comforts',
+      'Resentment toward others who have more',
+      'This state normalizes — you stop noticing the chains',
+    ],
+    driftWarning: 'This state normalizes. You stop noticing the chains because everyone around you wears them.',
+    strategies: [
+      'Name the chains first — write every dependency',
+      'One day without your biggest comfort',
+      'Sit in silence 10 minutes daily — no phone',
+      'Ask: who would I be without this?',
+    ],
+    quote: '"Seek not that the things which happen should happen as you wish; but wish the things which happen to be as they are."',
+    quoteBy: 'Epictetus, Enchiridion',
+    greekTerm: 'δουλεία · slavery to want',
+  },
+]
+
+const PHILOSOPHERS = [
+  { name: 'Diogenes', position: 5, color: '#c9a84c', desc: 'Lived in a barrel. Radical external subtraction as life.' },
+  { name: 'Epictetus', position: 18, color: '#a89060', desc: 'Slave who owned nothing, needed nothing. Inner freedom.' },
+  { name: 'Marcus', position: 32, color: '#a89060', desc: 'Emperor with unlimited access — declined it. Power without need.' },
+  { name: 'Seneca', position: 55, color: '#9a6a5a', desc: 'Preached detachment, lived in great wealth. Knew the gap.' },
+  { name: 'Epicurus', position: 70, color: '#7a6a8a', desc: 'Simple garden life. Goal still pleasure, even if refined.' },
+  { name: 'Modern Consumer', position: 92, color: '#8b2020', desc: 'Optimizing comfort. Every itch scratched. Soul restless, enslaved.' },
+]
+
+const DIAGNOSTICS = [
+  { label: 'The Silence Test', question: 'Can you sit alone in silence for 20 minutes with no input?', no: 'Epithumia zone. Discomfort with silence = dependency on stimulation.', yes: 'Neutral or left of it.' },
+  { label: 'The Removal Test', question: 'Remove your biggest comfort for one week. What happens?', no: 'Agitation, irritability → Hedonic drift or deeper. It owns you.', yes: 'Equanimity → Left zone. Strong signal.' },
+  { label: 'The Envy Test', question: "Whose life do you want when scrolling social media?", no: "Strong envy → Mimetic drift. You are borrowing others' desires.", yes: "No one's → Progressing well leftward." },
+  { label: 'The Disruption Test', question: 'When your routine breaks, how long until equilibrium?', no: 'Days of irritability → Epithumia. Hours → Hedonic drift.', yes: 'Minutes or none → Strong left signal.' },
+  { label: 'The Death Test', question: 'Contemplate your death right now. What arises?', no: 'Terror, avoidance → Deep attachment to outcomes and things.', yes: 'Calm curiosity → Near the left.' },
+  { label: 'The Praise Test', question: 'When criticized publicly, what do you feel?', no: 'Shame, anger, need to defend → Reputation dependency.', yes: 'Genuine indifference → Left signal.' },
+]
+
+const OBSTACLES = [
+  {
+    thinker: 'Borgmann',
+    title: 'The Device Paradigm',
+    sub: 'Technology & the Character of Contemporary Life',
+    color: '#a888cc',
+    border: '#6a4a8a',
+    bg: '#130e1a',
+    body: 'The device conceals its own machinery and delivers a commodity — warmth, entertainment, food — without engagement. A furnace replaces the hearth. A phone replaces presence. Each device silently removes a practice that built character.',
+    pull: 'Comfort delivered without effort erodes the capacity for voluntary hardship.',
+    resistance: 'Focal practices — cooking, running, craftsmanship. ἔργα.',
+  },
+  {
+    thinker: 'Girard',
+    title: 'Mimetic Desire',
+    sub: 'We want what others want',
+    color: '#cc8888',
+    border: '#8a3a3a',
+    bg: '#1a0e0e',
+    body: "Desire is not spontaneous — it is borrowed from a model. You don't want the object, you want their life. Social media is a mimetic desire accelerant. Infinite models, infinite objects to borrow desire from.",
+    pull: 'You accumulate not from need but from triangulated envy. The wanting never ends.',
+    resistance: 'Name your mimetic model. Whose life are you actually wanting?',
+  },
+  {
+    thinker: 'Debord',
+    title: 'The Spectacle',
+    sub: 'Life reduced to representation',
+    color: '#6aa0cc',
+    border: '#3a6a8a',
+    bg: '#0e1218',
+    body: 'Modern life is increasingly lived as spectacle — image, representation, performance rather than direct living. You document instead of experience. You perform identity instead of living it.',
+    pull: 'Identity becomes a consumption object. You need to be seen having the life.',
+    resistance: 'Do things that cannot be photographed. Sit in silence.',
+  },
+]
+
+// ── Sub-components ───────────────────────────────────────────────────────────
+
+function ScaleBar({ activeZone, onZoneClick }: { activeZone: number; onZoneClick: (i: number) => void }) {
+  return (
+    <div className={styles.scaleWrap}>
+      <div className={styles.scaleBar}>
+        {ZONES.map((z, i) => (
+          <button
+            key={z.id}
+            className={`${styles.scaleSegment} ${activeZone === i ? styles.scaleSegmentActive : ''}`}
+            style={{ '--zone-color': z.color } as React.CSSProperties}
+            onClick={() => onZoneClick(i)}
+            aria-label={z.label}
+          >
+            <span className={styles.scaleGreek}>{z.greek}</span>
+          </button>
+        ))}
+      </div>
+      <div className={styles.scaleLabels}>
+        {ZONES.map((z, i) => (
+          <button
+            key={z.id}
+            className={`${styles.scaleLabel} ${activeZone === i ? styles.scaleLabelActive : ''}`}
+            style={{ '--zone-color': z.color } as React.CSSProperties}
+            onClick={() => onZoneClick(i)}
+          >
+            {z.label}
+          </button>
+        ))}
+      </div>
+      <div className={styles.scaleDirections}>
+        <span style={{ color: '#c9a84c' }}>← Εὐδαιμονία increases</span>
+        <span style={{ color: '#8b2020' }}>Suffering increases →</span>
+      </div>
+    </div>
+  )
+}
+
+function ZoneCard({ zone, isActive }: { zone: typeof ZONES[0]; isActive: boolean }) {
+  return (
+    <div
+      className={`${styles.zoneCard} ${isActive ? styles.zoneCardActive : ''}`}
+      style={{
+        '--zone-color': zone.color,
+        '--zone-border': zone.borderColor,
+        '--zone-bg': zone.bg,
+      } as React.CSSProperties}
+    >
+      <div className={styles.zoneHeader}>
+        <div>
+          <div className={styles.zoneGreek}>{zone.greek}</div>
+          <div className={styles.zoneLabel}>{zone.label}</div>
+          <div className={styles.zoneSub}>{zone.sub}</div>
+        </div>
+        <div className={styles.zoneGreekTerm}>{zone.greekTerm}</div>
+      </div>
+
+      <div className={styles.zoneBody}>
+        <div className={styles.zoneSection}>
+          <div className={styles.zoneSectionLabel}>HOW IT FEELS</div>
+          <p className={styles.zoneSectionText}>{zone.howItFeels}</p>
+        </div>
+
+        <div className={styles.zoneSection}>
+          <div className={styles.zoneSectionLabel}>BEHAVIORAL MARKERS</div>
+          <ul className={styles.zoneList}>
+            {zone.markers.map((m, i) => <li key={i}>{m}</li>)}
+          </ul>
+        </div>
+
+        <div className={styles.zoneSection}>
+          <div className={styles.zoneSectionLabel}>DRIFT WARNING</div>
+          <p className={styles.zoneDrift}>{zone.driftWarning}</p>
+        </div>
+
+        <div className={styles.zoneSection}>
+          <div className={styles.zoneSectionLabel}>STRATEGIES</div>
+          <ul className={styles.zoneList}>
+            {zone.strategies.map((s, i) => <li key={i}>{s}</li>)}
+          </ul>
+        </div>
+
+        <blockquote className={styles.zoneQuote}>
+          <p>{zone.quote}</p>
+          <cite>— {zone.quoteBy}</cite>
+        </blockquote>
+      </div>
+    </div>
+  )
+}
+
+function PhilosopherMap() {
+  const [hovered, setHovered] = useState<number | null>(null)
+  return (
+    <div className={styles.philWrap}>
+      <div className={styles.philBar}>
+        <div className={styles.philLine} />
+        {PHILOSOPHERS.map((p, i) => (
+          <div
+            key={p.name}
+            className={styles.philMarker}
+            style={{ left: `${p.position}%`, '--phil-color': p.color } as React.CSSProperties}
+            onMouseEnter={() => setHovered(i)}
+            onMouseLeave={() => setHovered(null)}
+          >
+            <div className={styles.philDot} />
+            <div className={styles.philTick} />
+            <div className={`${styles.philTooltip} ${hovered === i ? styles.philTooltipVisible : ''}`}>
+              <strong>{p.name}</strong>
+              <span>{p.desc}</span>
+            </div>
+            <div className={`${styles.philName} ${i % 2 === 0 ? styles.philNameAbove : styles.philNameBelow}`}>
+              {p.name}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function DiagnosticCard({ d, index }: { d: typeof DIAGNOSTICS[0]; index: number }) {
+  const [revealed, setRevealed] = useState<'yes' | 'no' | null>(null)
+  return (
+    <div className={styles.diagCard}>
+      <div className={styles.diagNumber}>0{index + 1}</div>
+      <div className={styles.diagLabel}>{d.label}</div>
+      <p className={styles.diagQuestion}>{d.question}</p>
+      <div className={styles.diagButtons}>
+        <button
+          className={`${styles.diagBtn} ${styles.diagBtnNo} ${revealed === 'no' ? styles.diagBtnActive : ''}`}
+          onClick={() => setRevealed(revealed === 'no' ? null : 'no')}
+        >
+          No / Struggle
+        </button>
+        <button
+          className={`${styles.diagBtn} ${styles.diagBtnYes} ${revealed === 'yes' ? styles.diagBtnActive : ''}`}
+          onClick={() => setRevealed(revealed === 'yes' ? null : 'yes')}
+        >
+          Yes / Easily
+        </button>
+      </div>
+      {revealed && (
+        <div className={`${styles.diagResult} ${revealed === 'yes' ? styles.diagResultYes : styles.diagResultNo}`}>
+          {revealed === 'yes' ? d.yes : d.no}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ObstacleCard({ o }: { o: typeof OBSTACLES[0] }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div
+      className={`${styles.obstCard} ${open ? styles.obstCardOpen : ''}`}
+      style={{ '--obs-color': o.color, '--obs-border': o.border, '--obs-bg': o.bg } as React.CSSProperties}
+    >
+      <button className={styles.obstHeader} onClick={() => setOpen(!open)}>
+        <div>
+          <div className={styles.obstThinker}>{o.thinker}</div>
+          <div className={styles.obstTitle}>{o.title}</div>
+          <div className={styles.obstSub}>{o.sub}</div>
+        </div>
+        <span className={styles.obstChevron}>{open ? '−' : '+'}</span>
+      </button>
+      {open && (
+        <div className={styles.obstBody}>
+          <p>{o.body}</p>
+          <div className={styles.obstPull}>
+            <span className={styles.obstPullLabel}>→ Rightward pull:</span> {o.pull}
+          </div>
+          <div className={styles.obstResist}>
+            <span className={styles.obstResistLabel}>Resistance:</span> {o.resistance}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────────
+
+export default function FrameworkPage() {
+  const [activeZone, setActiveZone] = useState(2)
+  const zoneRefs = useRef<(HTMLDivElement | null)[]>([])
+  const sectionRefs = {
+    zones: useRef<HTMLDivElement>(null),
+    philosophers: useRef<HTMLDivElement>(null),
+    diagnostics: useRef<HTMLDivElement>(null),
+    obstacles: useRef<HTMLDivElement>(null),
+  }
+
+  const handleZoneClick = (i: number) => {
+    setActiveZone(i)
+    zoneRefs.current[i]?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }
+
+  const scrollTo = (ref: React.RefObject<HTMLDivElement | null>) => {
+    ref.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+
+  return (
+    <main className={styles.page}>
+
+      {/* ── Hero ── */}
+      <section className={styles.hero}>
+        <div className={styles.heroEyebrow}>ARETE · PHILOSOPHICAL FRAMEWORK</div>
+        <h1 className={styles.heroTitle}>
+          <span className={styles.heroGreek}>Κλίμακα Εὐδαιμονίας</span>
+          <span className={styles.heroEng}>The Scale of Happiness</span>
+        </h1>
+        <p className={styles.heroSub}>
+          Freedom is not given — it is earned by subtracting what enslaves you.
+          <br />
+          Locate yourself. Move left. Practice daily.
+        </p>
+        <div className={styles.heroRule} />
+        <ScaleBar activeZone={activeZone} onZoneClick={handleZoneClick} />
+        <div className={styles.heroNav}>
+          <button className={styles.heroNavBtn} onClick={() => scrollTo(sectionRefs.zones)}>I · The Zones</button>
+          <button className={styles.heroNavBtn} onClick={() => scrollTo(sectionRefs.philosophers)}>II · The Philosophers</button>
+          <button className={styles.heroNavBtn} onClick={() => scrollTo(sectionRefs.diagnostics)}>III · Diagnostic</button>
+          <button className={styles.heroNavBtn} onClick={() => scrollTo(sectionRefs.obstacles)}>IV · Obstacles</button>
+        </div>
+      </section>
+
+      {/* ── Zones ── */}
+      <section className={styles.section} ref={sectionRefs.zones}>
+        <div className={styles.sectionHeader}>
+          <span className={styles.sectionNum}>I</span>
+          <h2 className={styles.sectionTitle}>The Zones</h2>
+          <p className={styles.sectionDesc}>Click any zone on the scale above to jump to it. Each zone has behavioral markers, drift warnings, and practical strategies.</p>
+        </div>
+        <div className={styles.zoneGrid}>
+          {ZONES.map((z, i) => (
+            <div key={z.id} ref={el => { zoneRefs.current[i] = el }}>
+              <ZoneCard zone={z} isActive={activeZone === i} />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ── Philosophers ── */}
+      <section className={styles.section} ref={sectionRefs.philosophers}>
+        <div className={styles.sectionHeader}>
+          <span className={styles.sectionNum}>II</span>
+          <h2 className={styles.sectionTitle}>The Philosophers</h2>
+          <p className={styles.sectionDesc}>Hover each figure to see where they land and why. The same destination — different paths.</p>
+        </div>
+        <PhilosopherMap />
+        <div className={styles.philCards}>
+          {PHILOSOPHERS.map(p => (
+            <div key={p.name} className={styles.philCard} style={{ '--phil-color': p.color } as React.CSSProperties}>
+              <div className={styles.philCardName}>{p.name}</div>
+              <p className={styles.philCardDesc}>{p.desc}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ── Diagnostics ── */}
+      <section className={styles.section} ref={sectionRefs.diagnostics}>
+        <div className={styles.sectionHeader}>
+          <span className={styles.sectionNum}>III</span>
+          <h2 className={styles.sectionTitle}>Diagnostic</h2>
+          <p className={styles.sectionDesc}>Six tests. Answer honestly. Direction matters more than position — a man moving left from 2 is further along than a man stuck at 4.</p>
+        </div>
+        <div className={styles.diagGrid}>
+          {DIAGNOSTICS.map((d, i) => <DiagnosticCard key={i} d={d} index={i} />)}
+        </div>
+      </section>
+
+      {/* ── Obstacles ── */}
+      <section className={styles.section} ref={sectionRefs.obstacles}>
+        <div className={styles.sectionHeader}>
+          <span className={styles.sectionNum}>IV</span>
+          <h2 className={styles.sectionTitle}>The Obstacles</h2>
+          <p className={styles.sectionDesc}>Three thinkers from your corpus — what pulls you rightward, how it works, and how to resist.</p>
+        </div>
+        <div className={styles.obstGrid}>
+          {OBSTACLES.map(o => <ObstacleCard key={o.thinker} o={o} />)}
+        </div>
+        <div className={styles.masterObstacle}>
+          <h3 className={styles.masterTitle}>The Master Obstacle</h3>
+          <p className={styles.masterSub}>The deepest pull rightward is not any single force — it is that everyone around you is there.</p>
+          <div className={styles.masterGrid}>
+            <div><strong>Borgmann says</strong><p>Devices restructure life so thoroughly that resistance feels eccentric, not heroic.</p></div>
+            <div><strong>Girard says</strong><p>Your desire is shaped by those around you. In a culture of want, you will want.</p></div>
+            <div><strong>Debord says</strong><p>The spectacle is total. Opting out requires you to refuse the frame entirely.</p></div>
+            <div><strong>Stoic answer</strong><p>The obstacle is the way. Resistance to the current is the practice itself. <em>ἔργα οὐ λόγοι.</em></p></div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Footer ── */}
+      <footer className={styles.footer}>
+        <div className={styles.footerRule} />
+        <div className={styles.footerGreek}>ἔργα οὐ λόγοι</div>
+        <div className={styles.footerEng}>Deeds · Not · Words</div>
+        <a href="/academy" className={styles.footerCta}>Begin the Formation →</a>
+      </footer>
+
+    </main>
+  )
+}


### PR DESCRIPTION
Adds the `/framework` route to the academy site (`academy.pursuearete.com/framework`).

- Interactive scale bar (click a zone → scrolls + highlights)
- Zone cards with behavioral markers, drift warnings, strategies, Stoic quotes
- Philosopher map with placement-rationale tooltips
- Diagnostic Yes/No cards with animated results
- Obstacle accordions (Borgmann, Girard, Debord) + master-obstacle synthesis

Self-contained client component (two new files). Typechecks clean; no `@/` alias remapping needed. Split out from the daily-dispatch branch as its own task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)