### PR TITLE
style(academy): make framework scale bar stand out more

### DIFF
--- a/academy/web/src/app/framework/framework.module.css
+++ b/academy/web/src/app/framework/framework.module.css
@@ -74,11 +74,12 @@
 
 .scaleBar {
   display: flex;
-  height: 40px;
-  border-radius: 20px;
+  height: 52px;
+  border-radius: 26px;
   overflow: hidden;
-  border: 1px solid rgba(201, 168, 76, 0.2);
+  border: 1px solid rgba(201, 168, 76, 0.45);
   margin-bottom: 12px;
+  box-shadow: 0 0 28px rgba(201, 168, 76, 0.18), inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
 .scaleSegment {
@@ -91,22 +92,26 @@
   justify-content: center;
   transition: background 0.25s, flex 0.3s;
   position: relative;
+  box-shadow: inset -1px 0 0 rgba(0, 0, 0, 0.35);
+}
+.scaleSegment:last-child {
+  box-shadow: none;
 }
 
 .scaleSegment:first-child {
-  background: linear-gradient(90deg, rgba(201,168,76,0.35), rgba(201,168,76,0.1));
+  background: linear-gradient(90deg, rgba(201,168,76,0.75), rgba(201,168,76,0.3));
 }
 .scaleSegment:nth-child(2) {
-  background: linear-gradient(90deg, rgba(138,122,58,0.2), rgba(138,122,58,0.15));
+  background: linear-gradient(90deg, rgba(160,142,64,0.45), rgba(120,104,48,0.35));
 }
 .scaleSegment:nth-child(3) {
-  background: rgba(30, 58, 74, 0.3);
+  background: rgba(40, 74, 92, 0.55);
 }
 .scaleSegment:nth-child(4) {
-  background: linear-gradient(90deg, rgba(106,58,42,0.15), rgba(106,58,42,0.25));
+  background: linear-gradient(90deg, rgba(122,68,48,0.4), rgba(150,72,48,0.55));
 }
 .scaleSegment:last-child {
-  background: linear-gradient(90deg, rgba(139,32,32,0.2), rgba(139,32,32,0.4));
+  background: linear-gradient(90deg, rgba(160,40,40,0.55), rgba(170,36,36,0.8));
 }
 
 .scaleSegment:hover,
@@ -120,9 +125,10 @@
 }
 
 .scaleGreek {
-  font-size: 8px;
+  font-size: 9px;
   letter-spacing: 1px;
-  color: var(--zone-color);
+  color: #f2e6c2;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.7);
   opacity: 0;
   transition: opacity 0.2s;
   white-space: nowrap;
@@ -143,8 +149,8 @@
   flex: 1;
   background: none;
   border: none;
-  font-size: 10px;
-  color: #666;
+  font-size: 11px;
+  color: #9a9488;
   cursor: pointer;
   text-align: center;
   font-family: Georgia, serif;


### PR DESCRIPTION
Visual emphasis pass on the `/framework` scale bar so it reads more clearly against the dark background.

- Taller bar (40px → 52px), larger corner radius
- Gold outer glow + subtle top highlight; border opacity 0.2 → 0.45
- Richer per-zone gradients (gold → olive → teal → rust → deep red)
- Thin inset dividers between the five segments
- Brighter zone labels and cream Greek text with drop shadow

CSS-only change to `framework.module.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)