### PR TITLE
fix(academy): robust Vercel ignoreCommand for merge/shallow clones

### DIFF
--- a/academy/web/vercel.json
+++ b/academy/web/vercel.json
@@ -1,3 +1,3 @@
 {
-  "ignoreCommand": "! git diff HEAD^ HEAD --name-only | grep -qE '^academy/'"
+  "ignoreCommand": "git rev-parse HEAD^ >/dev/null 2>&1 && git diff --quiet HEAD^ HEAD -- academy/ || exit 1"
 }


### PR DESCRIPTION
The academy project's `ignoreCommand` used `! git diff HEAD^ HEAD --name-only | grep -qE '^academy/'`, which can skip the **production** deploy on merge commits where `HEAD^` isn't resolvable in Vercel's shallow clone — reporting "success" while the production alias stays on the prior build. This is what stranded the scale-bar change (PR #100) on the old deployment.

New command builds whenever `academy/` changed and builds-on-doubt when `HEAD^` can't be resolved:

```
git rev-parse HEAD^ >/dev/null 2>&1 && git diff --quiet HEAD^ HEAD -- academy/ || exit 1
```

Validated locally: academy-changed commit → exit 1 (build); non-academy commit → exit 0 (skip). Merging this also triggers a clean academy deploy that picks up the pending scale-bar CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)