### PR TITLE
fix(server): don’t crash at boot when OPENAI_API_KEY is unset

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -27,8 +27,15 @@ const PARALLEL_ENABLED = process.env.PARALLEL_CABINET_ENABLED === 'true';
 const PARALLEL_ALLOWLIST = (process.env.PARALLEL_CABINET_ALLOWLIST || '')
   .split(',').map(s => s.trim()).filter(Boolean);
 
-// OpenAI SDK client (used for OpenAI-backed agents and embeddings)
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+// OpenAI SDK client (used for OpenAI-backed counselor routing). Null when the
+// key is absent — same pattern as gemini/xai below, so a missing OPENAI_API_KEY
+// degrades gpt- counselors to Claude instead of crashing the server at boot.
+// (The openai v6 SDK throws at construction when apiKey is falsy.) Embeddings
+// use raw fetch elsewhere and are independently guarded on OPENAI_API_KEY.
+const openai = process.env.OPENAI_API_KEY
+  ? new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+  : null;
+if (!openai) console.warn('OPENAI_API_KEY not set — gpt- counselors will fall back to Claude.');
 
 // Gemini and Grok expose OpenAI-compatible APIs — same SDK, different base
 // URLs. Clients are null when the key is absent; routing then falls back to
@@ -75,7 +82,7 @@ function isNonAnthropicModel(model) {
  * the provider's key is missing, or undefined for Anthropic models.
  */
 function compatRouteFor(model) {
-  if (model.startsWith('gpt-')) return { client: openai, provider: 'openai' };
+  if (model.startsWith('gpt-')) return openai ? { client: openai, provider: 'openai' } : null;
   if (model.startsWith('gemini')) return gemini ? { client: gemini, provider: 'gemini' } : null;
   if (model.startsWith('grok')) return xai ? { client: xai, provider: 'xai' } : null;
   return undefined;


### PR DESCRIPTION
## Production fix — API server crashes at boot

The main Express server (`/app/index.js`) was crashing on deploy:

```
OpenAIError: Missing credentials. Please pass an `apiKey`... or set the `OPENAI_API_KEY` ...
    at new OpenAI (/app/node_modules/openai/client.js:143:19)
    at Object.<anonymous> (/app/index.js:31:16)
```

### Cause
The openai **v6** SDK throws at construction when `apiKey` is falsy. Line 31 built the client unconditionally, so a missing `OPENAI_API_KEY` took down the **entire** API at boot. (The same log shows `Key starts with: undefined` → `CLAUDE_API_KEY` is also unset on that Railway service.)

### Fix
Guard the `openai` client to `null` when the key is absent — the exact pattern the `gemini`/`xai` clients already use two lines below — and guard the `gpt-` branch of `compatRouteFor`. Effect: `gpt-` counselors fall back to Claude (existing `route === null` path), embeddings already no-op on a missing key, and the server boots. `node --check` passes; verified the client resolves to `null` with no key.

### ⚠️ Still required on Railway
This stops the crash, but the service is **missing its env vars**. Set on the API service: `OPENAI_API_KEY`, `CLAUDE_API_KEY` (Claude is core — the app barely functions without it), plus `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY`. Likely fallout from the earlier secret-exposure cleanup that stripped baked-in keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)