### PR TITLE
fix(academy): remove broken ignoreCommand freezing prod builds

### DIFF
--- a/academy/web/vercel.json
+++ b/academy/web/vercel.json
@@ -1,3 +1,1 @@
-{
-  "ignoreCommand": "git rev-parse HEAD^ >/dev/null 2>&1 && git diff --quiet HEAD^ HEAD -- academy/ || exit 1"
-}
+{}


### PR DESCRIPTION
The academy `ignoreCommand` (`git diff --quiet HEAD^ HEAD -- academy/`) returns "skip" on merge commits in Vercel's shallow clone, so the **Ignored Build Step cancels every academy production build**. Build log: *"The Deployment has been canceled as a result of running the command defined in the Ignored Build Step setting."*

Result: production was frozen on a stale build — the framework scale-bar update and the admin fleet-guide (#102) never went live, and stale CSS made the new admin UI render unstyled.

Fix: remove the `ignoreCommand` so academy always builds (~1 min). A smarter, correct path-filter can be reintroduced later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)