### PR TITLE
feat(synthesis): on-demand "Run synthesis" + fix truncated documents

### DIFF
--- a/academy/web/src/app/admin/synthesis/page.tsx
+++ b/academy/web/src/app/admin/synthesis/page.tsx
@@ -67,6 +67,9 @@ export default function SynthesisPage() {
   const [showIngested, setShowIngested] = useState(false)
   const [showRejected, setShowRejected] = useState(false)
 
+  // On-demand synthesis run.
+  const [running, setRunning] = useState(false)
+
   function showToast(msg: string) {
     setToast(msg)
     setTimeout(() => setToast(''), 3000)
@@ -93,6 +96,29 @@ export default function SynthesisPage() {
   }, [])
 
   useEffect(() => { load() }, [load])
+
+  async function runSynthesis() {
+    setRunning(true)
+    try {
+      const res = await fetch('/api/admin/synthesis/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ count: 3 }),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || 'Failed to start synthesis')
+      showToast('Synthesis started — generating 3 documents (~a minute). The list refreshes automatically.')
+      // The run is in the background on the server; give it time, then reload.
+      setTimeout(async () => {
+        await load()
+        setRunning(false)
+        showToast('Refreshed — any new documents are in Pending review')
+      }, 55000)
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : 'Failed to start synthesis')
+      setRunning(false)
+    }
+  }
 
   function toggleExpand(id: string, content: string) {
     setExpanded(prev => {
@@ -227,13 +253,23 @@ export default function SynthesisPage() {
       <div className={styles.card}>
         <div className={styles.cardTitleRow}>
           <span className={styles.cardTitle}>Pending review ({pending.length})</span>
-          <button className={styles.ghostBtn} style={{ height: 30, padding: '0 12px', fontSize: 12 }} onClick={load}>↺ Refresh</button>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button
+              className={styles.primaryBtn}
+              style={{ height: 30, padding: '0 12px', fontSize: 12 }}
+              disabled={running}
+              onClick={runSynthesis}
+            >
+              {running ? 'Generating…' : '✦ Run synthesis (3)'}
+            </button>
+            <button className={styles.ghostBtn} style={{ height: 30, padding: '0 12px', fontSize: 12 }} onClick={load}>↺ Refresh</button>
+          </div>
         </div>
 
         {pending.length === 0 ? (
           <p className={styles.muted}>
-            Nothing awaiting review. The agent generates documents each Monday at 6:00 AM ET — or run{' '}
-            <code>node server/synthesis-agent.js</code> manually.
+            Nothing awaiting review. The agent generates documents each Monday at 6:00 AM ET — or press{' '}
+            <strong>Run synthesis</strong> to generate three now.
           </p>
         ) : (
           pending.map(doc => {

--- a/academy/web/src/app/api/admin/synthesis/generate/route.ts
+++ b/academy/web/src/app/api/admin/synthesis/generate/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase-server'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 30
+
+const BACKEND_URL =
+  process.env.RAILWAY_BACKEND_URL ||
+  process.env.NEXT_PUBLIC_API_BASE_URL ||
+  'https://arete-app-production.up.railway.app'
+
+// POST /api/admin/synthesis/generate — admin-only. Triggers an on-demand run of
+// the synthesis agent on Railway (default 3 documents). The run happens in the
+// background on the server, so this returns as soon as it's started.
+export async function POST(req: NextRequest) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user || user.email !== process.env.ADMIN_EMAIL) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: { session } } = await supabase.auth.getSession()
+  const token = session?.access_token
+  if (!token) {
+    return NextResponse.json({ error: 'No active session' }, { status: 401 })
+  }
+
+  let count = 3
+  try {
+    const body = await req.json()
+    if (body && Number.isFinite(body.count)) count = body.count
+  } catch {
+    /* default count */
+  }
+
+  try {
+    const upstream = await fetch(`${BACKEND_URL}/api/admin/synthesis/generate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ count }),
+    })
+    const respBody = await upstream.text()
+    return new NextResponse(respBody, {
+      status: upstream.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (e) {
+    console.error('[admin/synthesis/generate] upstream error:', e)
+    return NextResponse.json({ error: 'Failed to reach the synthesis agent.' }, { status: 502 })
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -16,6 +16,7 @@ const { Resend } = require('resend');
 const { getRelevantChunks } = require('./retrieval');
 const libraryHelpers = require('./library');
 const { runDispatchGeneration } = require('./dispatch-generation-agent');
+const { runSynthesisAgent } = require('./synthesis-agent');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -2845,6 +2846,39 @@ app.post('/api/admin/dispatch/generate', async (req, res) => {
   } catch (err) {
     console.error('[/api/admin/dispatch/generate] error:', err.message);
     return res.status(500).json({ error: err.message || 'Generation failed' });
+  }
+});
+
+// POST /api/admin/synthesis/generate — run the synthesis agent on demand (admin
+// only), generating N documents (default 3) into pending_review. Generating
+// several Sonnet documents can exceed a serverless timeout, so this kicks the
+// run off in the background and returns immediately; the admin refreshes to see
+// the new documents. A module-level flag prevents overlapping runs.
+let synthesisRunning = false;
+app.post('/api/admin/synthesis/generate', async (req, res) => {
+  try {
+    const userId = await getAuthenticatedUserId(req);
+    if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+    if (!(await isAdmin(userId))) return res.status(403).json({ error: 'Forbidden' });
+    if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY || !CLAUDE_API_KEY) {
+      return res.status(500).json({ error: 'Server not configured for synthesis generation' });
+    }
+    if (synthesisRunning) {
+      return res.status(409).json({ error: 'A synthesis run is already in progress' });
+    }
+
+    const count = Math.max(1, Math.min(5, parseInt(req.body?.count, 10) || 3));
+    synthesisRunning = true;
+    runSynthesisAgent({ count })
+      .then(r => console.log('[synthesis/generate] complete:', JSON.stringify(r)))
+      .catch(e => console.error('[synthesis/generate] run error:', e.message))
+      .finally(() => { synthesisRunning = false; });
+
+    return res.json({ ok: true, started: true, count });
+  } catch (err) {
+    synthesisRunning = false;
+    console.error('[/api/admin/synthesis/generate] error:', err.message);
+    return res.status(500).json({ error: err.message || 'Failed to start synthesis' });
   }
 });
 

--- a/server/synthesis-agent.js
+++ b/server/synthesis-agent.js
@@ -299,13 +299,19 @@ async function callClaude(system, userPrompt) {
     },
     body: JSON.stringify({
       model: 'claude-sonnet-4-6',
-      max_tokens: 3000,
+      // A ~2000-word synthesis runs ~2700-3200 tokens; the old 3000 cap cut
+      // documents off mid-sentence. Give ample headroom so they finish.
+      max_tokens: 8000,
       system,
       messages: [{ role: 'user', content: userPrompt }],
     }),
   });
   if (!res.ok) throw new Error(`Claude API ${res.status}: ${await res.text()}`);
-  return res.json();
+  const json = await res.json();
+  if (json.stop_reason === 'max_tokens') {
+    console.warn('  ⚠ generation hit max_tokens — document may be truncated');
+  }
+  return json;
 }
 
 async function generateSynthesis(concept, passages, synthesisType, config) {
@@ -353,7 +359,10 @@ Put the title on the first line, then the document.`;
 
 // --- 2f. Main loop ---------------------------------------------------------
 
-async function runSynthesisAgent() {
+// options.count — generate exactly this many documents on demand (overrides the
+// configured documents_per_week, e.g. the admin "Run synthesis" button).
+// Returns a summary so callers can report results.
+async function runSynthesisAgent(options = {}) {
   const startTime = Date.now();
   console.log(`=== Synthesis Agent — ${new Date().toISOString()} ===`);
 
@@ -369,11 +378,16 @@ async function runSynthesisAgent() {
     console.warn('OPENAI_API_KEY not set — semantic source retrieval will be skipped.');
   }
 
-  const config = await getAgentConfig();
-  if (!config.enabled) {
+  const baseConfig = await getAgentConfig();
+  if (!baseConfig.enabled && !options.count) {
     console.log('Synthesis agent disabled in config. Exiting.');
-    return;
+    return { succeeded: 0, skipped: 0, failed: 0, disabled: true, titles: [] };
   }
+  // A manual run with an explicit count overrides documents_per_week (and runs
+  // even when the scheduled agent is disabled).
+  const config = options.count
+    ? { ...baseConfig, documents_per_week: Math.max(1, options.count) }
+    : baseConfig;
 
   const concepts = await selectConceptsForSynthesis(config);
   console.log(`Selected ${concepts.length} concept(s) for synthesis this week:`);
@@ -381,11 +395,12 @@ async function runSynthesisAgent() {
 
   if (concepts.length === 0) {
     console.log('\nNo eligible concepts (no journal_analysis demand and no structural fallback). Exiting.');
-    return;
+    return { succeeded: 0, skipped: 0, failed: 0, titles: [], reason: 'no_eligible_concepts' };
   }
 
   const generationWeek = getMondayOfCurrentWeek();
   let succeeded = 0, failed = 0, skipped = 0;
+  const titles = [];
 
   for (const { concept, userFrequency, demandRank } of concepts) {
     try {
@@ -425,6 +440,7 @@ async function runSynthesisAgent() {
 
       console.log(`  ✓ Generated: "${result.title}" (${result.wordCount} words) — pending review`);
       succeeded++;
+      titles.push(result.title);
 
       // Rate limit — synthesis calls are expensive.
       await new Promise(resolve => setTimeout(resolve, 2000));
@@ -439,6 +455,8 @@ async function runSynthesisAgent() {
   console.log(`All documents pending admin review at academy.pursuearete.com/admin/synthesis`);
   console.log(`Run time: ${((Date.now() - startTime) / 1000).toFixed(1)}s`);
   console.log(`===================`);
+
+  return { succeeded, skipped, failed, titles, generationWeek };
 }
 
 // Exported for testing / manual invocation; only auto-runs as a CLI.


### PR DESCRIPTION
- Truncation: callClaude capped at max_tokens 3000, but a ~2000-word synthesis runs ~2700-3200 tokens, so documents were cut off mid-sentence. Raise to 8000 and warn when stop_reason is max_tokens.
- runSynthesisAgent({ count }) generates an explicit number of documents (and runs even if the scheduled agent is disabled), returning a summary.
- POST /api/admin/synthesis/generate (admin-gated): kicks off a background run of 3 documents; returns immediately (several Sonnet calls exceed a serverless timeout). Vercel proxy + "✦ Run synthesis (3)" button on the admin page, which auto-refreshes to show the new pending documents.