### PR TITLE
fix(gap-agent): exclude Arete syntheses from demand-gap review passages

### DIFF
--- a/academy/web/src/app/api/admin/gap-agent/run/route.ts
+++ b/academy/web/src/app/api/admin/gap-agent/run/route.ts
@@ -73,6 +73,9 @@ async function getConceptPassages(admin: Admin, concept: string): Promise<CPM[]>
     .select('chunk_id, author, work, chunk_text, approved, similarity_score')
     .eq('concept', concept)
     .not('approved', 'is', false)
+    // Coverage is about primary sources; the corpus's own syntheses must not
+    // count as coverage or appear as candidate source passages.
+    .neq('author', 'Arete Synthesis')
   return (data as CPM[]) || []
 }
 
@@ -120,6 +123,10 @@ async function detectDemandGaps(admin: Admin, startTime: number) {
         })
         searchedFresh = true
         for (const chunk of (retrieved as { id: string; author: string; work: string; chunk_text: string; similarity: number }[]) || []) {
+          // Never surface the corpus's own syntheses as candidate source
+          // passages: they would mask real primary-source gaps, and the
+          // synthesis agent ignores synthesis-authored passages anyway.
+          if (chunk.author === 'Arete Synthesis') continue
           if (!passages.find(p => p.chunk_id === chunk.id)) {
             await admin.from('concept_passage_map').upsert({
               concept: theme,

--- a/server/coverage-gap-agent.js
+++ b/server/coverage-gap-agent.js
@@ -120,7 +120,10 @@ async function getConceptPassages(concept) {
     .from('concept_passage_map')
     .select('chunk_id, author, work, chunk_text, approved, similarity_score')
     .eq('concept', concept)
-    .not('approved', 'is', false);
+    .not('approved', 'is', false)
+    // Coverage is about primary sources; the corpus's own syntheses must not
+    // count as coverage or appear as candidate source passages.
+    .neq('author', 'Arete Synthesis');
   return data || [];
 }
 
@@ -172,6 +175,10 @@ async function detectDemandGaps() {
         // Upsert newly retrieved passages as unreviewed (don't clobber prior
         // approvals — onConflict only fills the row if it's new).
         for (const chunk of retrieved || []) {
+          // Never surface the corpus's own syntheses as candidate source
+          // passages: they would mask real primary-source gaps, and the
+          // synthesis agent ignores synthesis-authored passages anyway.
+          if (chunk.author === 'Arete Synthesis') continue;
           const exists = passages.find(p => p.chunk_id === chunk.id);
           if (!exists) {
             await supabase


### PR DESCRIPTION
Coverage gaps are about primary-source coverage, but the demand-gap semantic search ran over all of rag_corpus — including the corpus's own ingested syntheses — and mapped them into concept_passage_map as candidate source passages. That masked real gaps, wasted review effort (the synthesis agent now ignores synthesis-authored passages), and listed "Arete Synthesis" as a voice in the Observatory.

- getConceptPassages: filter out author='Arete Synthesis'
- demand-gap retrieval loop: skip synthesis-authored chunks before upsert Applied to both the cron agent (server/coverage-gap-agent.js) and the on-demand admin route. (10 stale synthesis rows already in concept_passage_map were removed separately; none were human-approved.)