### PR TITLE
feat(admin): bigger corpus paste box + draft save/restore

### DIFF
--- a/academy/web/src/app/admin/admin.module.css
+++ b/academy/web/src/app/admin/admin.module.css
@@ -584,19 +584,44 @@
 .textInput::placeholder { color: #bbb; }
 
 .bigTextarea {
-  min-height: 300px;
-  padding: 10px;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 480px;
+  padding: 14px;
   border: 0.5px solid #ddd;
   border-radius: 8px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 12px;
-  line-height: 1.6;
+  font-size: 13.5px;
+  line-height: 1.7;
   color: #1a1a1a;
   background: #fff;
   resize: vertical;
   outline: none;
 }
 .bigTextarea:focus { border-color: #AFA9EC; }
+
+/* Draft save/restore bar */
+.draftBar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+.draftBar .muted { font-size: 12px; }
+.draftNote {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  border: 0.5px solid #C9C2F0;
+  border-radius: 8px;
+  background: #F4F2FE;
+  font-size: 12px;
+  color: #4A4A6A;
+}
 
 .modeOption {
   display: flex;
@@ -975,6 +1000,7 @@
   }
   .modeOption { color: #ccc; }
   .placeholder { color: #777; }
+  .draftNote { background: #1B1830; border-color: #3A3470; color: #CFCBF5; }
   .pdCheckbox { background: #2A2310; border-color: #5C4A1E; color: #E5C77A; }
   .successBanner { background: #0E3A2E; border-color: #1D6E56; color: #9FE1CB; }
   .errorBanner { background: #3A1414; border-color: #6E2929; color: #F0B5B5; }

--- a/academy/web/src/app/admin/corpus/page.tsx
+++ b/academy/web/src/app/admin/corpus/page.tsx
@@ -20,6 +20,31 @@ function countWords(s: string): number {
   return s.split(/\s+/).filter(Boolean).length
 }
 
+const DRAFT_KEY = 'corpus-ingest:draft'
+
+type Draft = {
+  inputText: string
+  author: string
+  work: string
+  section: string
+  pages: string
+  language: 'en' | 'grc' | 'lat'
+  courseRelevance: string
+  difficulty: string
+  mode: Mode
+  savedAt: number
+}
+
+function timeAgo(ts: number): string {
+  const s = Math.floor((Date.now() - ts) / 1000)
+  if (s < 60) return 'just now'
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m} min ago`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h} hr ago`
+  return new Date(ts).toLocaleString()
+}
+
 export default function CorpusIngestPage() {
   // Same admin gate as the main /admin page.
   const [authLoading, setAuthLoading] = useState(true)
@@ -45,6 +70,10 @@ export default function CorpusIngestPage() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [coverage, setCoverage] = useState<Coverage | null>(null)
 
+  // Draft state (saved to the browser so work isn't lost on refresh/navigation)
+  const [savedDraft, setSavedDraft] = useState<Draft | null>(null)
+  const [draftSavedAt, setDraftSavedAt] = useState<number | null>(null)
+
   useEffect(() => {
     supabase.auth.getUser().then(({ data }) => {
       if (data.user?.email === process.env.NEXT_PUBLIC_ADMIN_EMAIL) {
@@ -68,6 +97,46 @@ export default function CorpusIngestPage() {
   useEffect(() => {
     if (authorized) loadCoverage()
   }, [authorized, loadCoverage])
+
+  // On load, surface any draft saved in this browser so it can be restored.
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(DRAFT_KEY)
+      if (!raw) return
+      const d = JSON.parse(raw) as Draft
+      if (d && (d.inputText || d.author || d.work)) setSavedDraft(d)
+    } catch {
+      // ignore malformed/unavailable storage
+    }
+  }, [])
+
+  const saveDraft = useCallback(() => {
+    const d: Draft = {
+      inputText, author, work, section, pages, language, courseRelevance, difficulty, mode,
+      savedAt: Date.now(),
+    }
+    try {
+      localStorage.setItem(DRAFT_KEY, JSON.stringify(d))
+      setDraftSavedAt(d.savedAt)
+      setSavedDraft(null) // current form now matches the saved draft
+    } catch {
+      // ignore quota/availability errors
+    }
+  }, [inputText, author, work, section, pages, language, courseRelevance, difficulty, mode])
+
+  function restoreDraft() {
+    if (!savedDraft) return
+    setInputText(savedDraft.inputText)
+    setAuthor(savedDraft.author)
+    setWork(savedDraft.work)
+    setSection(savedDraft.section)
+    setPages(savedDraft.pages)
+    setLanguage(savedDraft.language)
+    setCourseRelevance(savedDraft.courseRelevance)
+    setDifficulty(savedDraft.difficulty)
+    setMode(savedDraft.mode)
+    setSavedDraft(null)
+  }
 
   const canStart = author.trim() && work.trim() && inputText.trim().length > 0
 
@@ -160,6 +229,10 @@ export default function CorpusIngestPage() {
     setResult(null)
     setErrorMessage(null)
     setStatus('idle')
+    // Clear the saved draft once a passage has been ingested.
+    try { localStorage.removeItem(DRAFT_KEY) } catch { /* ignore */ }
+    setSavedDraft(null)
+    setDraftSavedAt(null)
   }
 
   if (authLoading) {
@@ -184,6 +257,14 @@ export default function CorpusIngestPage() {
         {/* ── Left: source text ────────────────────────────── */}
         <div className={styles.card}>
           <div className={styles.sectionLabel}>Source text</div>
+
+          {savedDraft && (
+            <div className={styles.draftNote}>
+              <span>📝 Draft saved {timeAgo(savedDraft.savedAt)}{savedDraft.work ? ` — “${savedDraft.work}”` : ''}.</span>
+              <button type="button" className={styles.ghostBtn} onClick={restoreDraft}>Restore</button>
+              <button type="button" className={styles.ghostBtn} onClick={() => setSavedDraft(null)}>Dismiss</button>
+            </div>
+          )}
 
           <div className={styles.field}>
             <label className={styles.fieldLabel}>Author *</label>
@@ -263,7 +344,22 @@ export default function CorpusIngestPage() {
             <span className={styles.charCount}>{inputText.length.toLocaleString()} characters</span>
           </div>
 
-          <div className={styles.generateRow}>
+          <div className={styles.generateRow} style={{ justifyContent: 'space-between', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+            <div className={styles.draftBar}>
+              <button
+                type="button"
+                className={styles.ghostBtn}
+                onClick={saveDraft}
+                disabled={!inputText.trim() && !author.trim() && !work.trim()}
+              >
+                ⤓ Save draft
+              </button>
+              {draftSavedAt && (
+                <span className={styles.muted}>
+                  ✓ Saved {new Date(draftSavedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                </span>
+              )}
+            </div>
             <button
               className={styles.primaryBtn}
               disabled={!canStart || status === 'summarizing' || status === 'ingesting'}


### PR DESCRIPTION
Improves the **Corpus passage ingestion** admin page (`/admin/corpus`).

### Bigger paste box
The "Paste text" textarea was missing `width: 100%` (narrower than the summary box) and only 300px tall. Now full-width, **480px tall**, larger font (12→13.5px), more padding/line-height. Still drag-resizable.

### Draft save / restore
- **⤓ Save draft** button persists everything in progress — pasted text *and* all fields (author, work, section, pages, language, difficulty, course relevance, mode) — to the browser (localStorage). Shows a "✓ Saved HH:MM" confirmation.
- On returning to the page, a banner offers to **Restore** the last draft (or Dismiss).
- Draft **auto-clears** after a passage is successfully ingested.

Scope: only `admin/corpus/page.tsx` and `admin.module.css` (the shared admin stylesheet, additive changes). Does **not** touch the library/observatory page. Verified with `next build` (compiles clean). Drafts are per-browser (localStorage); cross-device sync would need a Supabase-backed store — can follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)