### PR TITLE
feat(corpus): harden fetch guard + on-demand Run ingestion now

### DIFF
--- a/academy/corpus-ingestion/corpus-agent.js
+++ b/academy/corpus-ingestion/corpus-agent.js
@@ -82,13 +82,38 @@ async function fetchSourceText(url) {
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
   if (!res.ok) throw new Error(`fetch returned ${res.status}`);
+
+  // An honest text/html content-type is an immediate reject. (Note: some
+  // archives/proxies mislabel HTML as text/plain, so this is necessary but
+  // not sufficient — the body sniff below is the real guard.)
+  const contentType = (res.headers.get('content-type') || '').toLowerCase();
+  if (contentType.includes('text/html')) {
+    throw new Error(`source is HTML (content-type: ${contentType}), not plain text`);
+  }
+
   const body = await res.text();
   if (!body || body.length < 1000) {
     throw new Error(`fetched body too small (${body ? body.length : 0} bytes)`);
   }
-  const head = body.slice(0, 500).toLowerCase();
-  if (head.includes('<!doctype html') || head.includes('<html')) {
-    throw new Error('fetched an HTML page, not the expected text');
+
+  // Reject binary blobs (e.g. a PDF URL) before they get chunked into gibberish.
+  if (/^\s*%PDF-/.test(body) || body.slice(0, 4096).includes(String.fromCharCode(0))) {
+    throw new Error('source looks binary (e.g. a PDF) — supply the plain-text version');
+  }
+
+  // Reject HTML/markup even when it doesn't open with <!doctype>/<html>: many
+  // archive and Google-cache pages wrap the text in <base>/<table>/<font>, and
+  // those still chunk into useless tag-soup. We still allow PerseusDL TEI XML
+  // (grc/lat sources), which opens with <?xml or <TEI rather than HTML tags.
+  const head = body.slice(0, 1500).toLowerCase();
+  const looksXml = /^\s*<\?xml|^\s*<tei\b/.test(head);
+  const HTML_MARKERS = [
+    '<!doctype html', '<html', '<head>', '<head ', '<body', '<base ', '<base>',
+    '<table', '<div', '<span', '<font', '<script', '<style', '<meta ', '<link ',
+    '<td>', '<td ', '<tr>', '<tr ', '<a href',
+  ];
+  if (!looksXml && HTML_MARKERS.some(m => head.includes(m))) {
+    throw new Error('fetched an HTML/markup page, not the expected plain text');
   }
   return body;
 }

--- a/academy/web/src/app/admin/CorpusAgentPanel.tsx
+++ b/academy/web/src/app/admin/CorpusAgentPanel.tsx
@@ -71,6 +71,8 @@ export default function CorpusAgentPanel({ onHealth }: { onHealth?: (h: Health) 
   const [data, setData] = useState<CorpusData | null>(null)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
+  const [running, setRunning] = useState(false)
+  const [runMsg, setRunMsg] = useState('')
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -89,6 +91,22 @@ export default function CorpusAgentPanel({ onHealth }: { onHealth?: (h: Health) 
   }, [onHealth])
 
   useEffect(() => { load() }, [load])
+
+  const runNow = useCallback(async () => {
+    setRunning(true)
+    setRunMsg('')
+    try {
+      const res = await fetch('/api/admin/corpus-agent/run', { method: 'POST' })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || 'Failed to start the agent')
+      setRunMsg('✓ Ingestion started on Railway — it drains the queue and logs a run here. Refresh in a minute or two.')
+      // Give Railway a moment to spin up + create the run row, then refresh.
+      setTimeout(() => load(), 10000)
+    } catch (e) {
+      setRunMsg(e instanceof Error ? e.message : 'Failed to start the agent')
+    }
+    setRunning(false)
+  }, [load])
 
   if (loading && !data) {
     return (
@@ -132,8 +150,22 @@ export default function CorpusAgentPanel({ onHealth }: { onHealth?: (h: Health) 
   return (
     <div className={styles.page}>
       <div className={styles.header}>
-        <h1>RAG Corpus agent</h1>
-        <p>Nightly autonomous ingestion into the rag_corpus table.</p>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 16, flexWrap: 'wrap' }}>
+          <div>
+            <h1>RAG Corpus agent</h1>
+            <p>Nightly autonomous ingestion into the rag_corpus table.</p>
+          </div>
+          <button
+            className={styles.primaryBtn}
+            onClick={runNow}
+            disabled={running}
+            style={{ flexShrink: 0 }}
+            title="Trigger the nightly ingestion agent now (drains the queue)"
+          >
+            {running ? 'Starting…' : '▶ Run ingestion now'}
+          </button>
+        </div>
+        {runMsg && <p className={styles.muted} style={{ marginTop: 8 }}>{runMsg}</p>}
       </div>
 
       {/* Last run */}

--- a/academy/web/src/app/api/admin/corpus-agent/run/route.ts
+++ b/academy/web/src/app/api/admin/corpus-agent/run/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase-server'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 30
+
+// Triggers the nightly Corpus Agent on demand. The agent is a separate Railway
+// cron service (academy/corpus-ingestion, `node corpus-agent.js`, schedule
+// "0 8 * * *"); this asks Railway to deploy it now, which runs the exact same
+// code that runs nightly — it drains corpus_ingestion_queue and writes a row to
+// corpus_ingestion_runs (which the Corpus Agent panel already displays).
+//
+// No ingestion work happens in this request, so there's no serverless timeout
+// risk — we just fire the Railway mutation and return.
+
+const RAILWAY_GQL = 'https://backboard.railway.com/graphql/v2'
+
+// Stable infra identifiers for the corpus-ingestion service (not secrets).
+// Overridable via env in case the project/service is recreated.
+const PROJECT_ID = process.env.RAILWAY_PROJECT_ID || '2a9389d7-2424-45b5-9416-65bb28122d9d'
+const SERVICE_ID = process.env.RAILWAY_CORPUS_SERVICE_ID || '61526a1e-2bf2-484a-b287-d000cd523ecd'
+const ENVIRONMENT_ID = process.env.RAILWAY_ENVIRONMENT_ID || '8aeea6b1-4c41-4603-94ba-8291db5b65df'
+
+export async function POST() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user || user.email !== process.env.ADMIN_EMAIL) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const token = process.env.RAILWAY_API_TOKEN
+  if (!token) {
+    return NextResponse.json(
+      {
+        error:
+          'RAILWAY_API_TOKEN is not set. Add a Railway account/team API token as ' +
+          'RAILWAY_API_TOKEN in the academy Vercel project env vars, then redeploy.',
+      },
+      { status: 503 }
+    )
+  }
+
+  const query = `
+    mutation RunCorpusAgent($input: EnvironmentTriggersDeployInput!) {
+      environmentTriggersDeploy(input: $input)
+    }`
+  const variables = {
+    input: { environmentId: ENVIRONMENT_ID, projectId: PROJECT_ID, serviceId: SERVICE_ID },
+  }
+
+  try {
+    const res = await fetch(RAILWAY_GQL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ query, variables }),
+    })
+    const json = await res.json().catch(() => ({}))
+    if (!res.ok || (json.errors && json.errors.length)) {
+      const msg = json.errors?.map((e: { message: string }) => e.message).join('; ')
+        || `Railway API returned ${res.status}`
+      return NextResponse.json({ error: msg }, { status: 502 })
+    }
+    return NextResponse.json({ success: true })
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : 'Failed to reach Railway' },
+      { status: 502 }
+    )
+  }
+}


### PR DESCRIPTION
Two corpus-ingestion reliability improvements.

### 1. Hardened fetch guard (`academy/corpus-ingestion/corpus-agent.js`)
The old guard only rejected bodies starting with `<!doctype html>`/`<html>`, so HTML-wrapped pages slipped through and got chunked into tag-soup, and PDFs decoded to binary gibberish. Now `fetchSourceText` also rejects:
- Honest `text/html` content-types
- Binary blobs — `%PDF-` magic / NUL bytes
- HTML/markup wrappers even without `<html>` (e.g. `<base>`/`<table>`/`<font>` Google-cache pages served as `text/plain`)

…while still allowing PerseusDL **TEI XML** (`<?xml`/`<TEI`) for Greek/Latin sources. Verified against real URLs: archive.org `_djvu.txt` and Gutenberg → **accept**; the MIT `classics.mit.edu` HTML-wrapped `.txt` and the Seneca PDF → **reject**.

### 2. "Run ingestion now" button (Corpus Agent tab)
Adds a button to the **Corpus Agent** admin tab that triggers the nightly ingestion on demand instead of waiting for the 08:00 UTC cron. New admin-only route `POST /api/admin/corpus-agent/run` calls the Railway API (`environmentTriggersDeploy`) to deploy the `corpus-ingestion` cron service, which runs the **exact same** `corpus-agent.js` — no duplicated pipeline, no serverless-timeout risk. It then logs a run row the panel already displays.

**Setup required:** add `RAILWAY_API_TOKEN` (a Railway account/team API token) to the academy Vercel project's env vars and redeploy. The project/service/env IDs are baked in with env overrides (`RAILWAY_PROJECT_ID` / `RAILWAY_CORPUS_SERVICE_ID` / `RAILWAY_ENVIRONMENT_ID`). Until the token is set, the button returns a clear "RAILWAY_API_TOKEN is not set" message.

Build: `next build` green; both routes compile. The Railway trigger mutation couldn't be live-tested without the token — worth a quick confirm after the token's added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)