### PR TITLE
feat(academy): conversation with the Interlocutor after the critique

### DIFF
--- a/academy/supabase/migrations/005_critique_messages.sql
+++ b/academy/supabase/migrations/005_critique_messages.sql
@@ -1,0 +1,42 @@
+-- Conversation with the Interlocutor, after the critique.
+--
+-- A critique is the opening move, not the whole exchange: the spec anticipates
+-- the student pushing back and asking again ("Do this every time, including
+-- when they insist"), which only happens across turns. Those turns are part of
+-- the teaching record and belong in the history the profile is derived from.
+--
+-- A separate append-only table rather than a `conversation` column on
+-- critique_history, because critique_history deliberately has no UPDATE policy:
+-- a critique is a record of what was said, not a document. Rewriting the row to
+-- append a turn would have meant handing back the update path that rule exists
+-- to close. Here every turn is its own insert.
+
+create table if not exists public.critique_messages (
+  id          uuid primary key default gen_random_uuid(),
+  critique_id uuid not null references public.critique_history(id) on delete cascade,
+  user_id     uuid not null references auth.users(id) on delete cascade,
+  role        text not null check (role in ('user', 'assistant')),
+  content     text not null,
+  created_at  timestamptz not null default now()
+);
+
+alter table public.critique_messages enable row level security;
+
+create policy "critique_messages_select_own" on public.critique_messages
+  for select using (auth.uid() = user_id);
+
+create policy "critique_messages_insert_own" on public.critique_messages
+  for insert with check (auth.uid() = user_id);
+
+create policy "critique_messages_delete_own" on public.critique_messages
+  for delete using (auth.uid() = user_id);
+
+-- No update policy, for the same reason critique_history has none.
+
+create policy "critique_messages_admin_select" on public.critique_messages
+  for select using (
+    exists (select 1 from public.profiles p where p.id = auth.uid() and p.is_admin)
+  );
+
+create index if not exists critique_messages_critique_idx
+  on public.critique_messages (critique_id, created_at);

--- a/academy/web/src/app/api/interlocutor/chat/route.ts
+++ b/academy/web/src/app/api/interlocutor/chat/route.ts
@@ -1,0 +1,154 @@
+import { NextRequest, NextResponse } from 'next/server'
+import Anthropic from '@anthropic-ai/sdk'
+import { createClient } from '@/lib/supabase-server'
+import {
+  INTERLOCUTOR_SYSTEM,
+  CONVERSATION_APPENDIX,
+  buildProfileBlock,
+  type WritingProfileRow,
+} from '@/lib/interlocutor'
+
+// POST /api/interlocutor/chat — talk with the Interlocutor about a piece.
+//
+// Anchored to a draft, always. The agent's domain is craft on a specific
+// argument, and an unanchored chat box turns it into a general assistant, which
+// is the one thing the spec is built to prevent. The draft rides in the first
+// message whether or not a critique has been run.
+//
+// Turns persist to critique_messages when the conversation follows a critique.
+// Without one there is no row to hang them on, so the exchange is ephemeral;
+// that is the cost of letting the student ask a question before submitting.
+//
+// Body: { excerpt, critique?, critiqueId?, pieceTitle?, messages: [{role, content}] }
+// Returns: { reply, recorded }
+
+const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
+
+export const maxDuration = 300
+
+const MAX_EXCERPT = 60000
+const MAX_TURNS = 40
+const MAX_TURN_CHARS = 8000
+
+type Turn = { role: 'user' | 'assistant'; content: string }
+
+export async function POST(req: NextRequest) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: {
+    excerpt?: string
+    critique?: string
+    critiqueId?: string
+    pieceTitle?: string
+    messages?: Turn[]
+  }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const excerpt = typeof body.excerpt === 'string' ? body.excerpt.trim() : ''
+  if (!excerpt) {
+    return NextResponse.json(
+      { error: 'There is no draft to talk about. Write something first.' },
+      { status: 400 }
+    )
+  }
+  if (excerpt.length > MAX_EXCERPT) {
+    return NextResponse.json({ error: 'That draft is too long to discuss in one thread.' }, { status: 400 })
+  }
+
+  const turns = Array.isArray(body.messages) ? body.messages.slice(-MAX_TURNS) : []
+  if (turns.length === 0 || turns[turns.length - 1].role !== 'user') {
+    return NextResponse.json({ error: 'The last message must be from the student.' }, { status: 400 })
+  }
+  for (const m of turns) {
+    if ((m.role !== 'user' && m.role !== 'assistant') || typeof m.content !== 'string' || !m.content.trim() || m.content.length > MAX_TURN_CHARS) {
+      return NextResponse.json({ error: 'Malformed message' }, { status: 400 })
+    }
+  }
+
+  const critique = typeof body.critique === 'string' ? body.critique.trim() : ''
+  const critiqueId = typeof body.critiqueId === 'string' ? body.critiqueId : null
+  const pieceTitle =
+    typeof body.pieceTitle === 'string' && body.pieceTitle.trim()
+      ? body.pieceTitle.trim().slice(0, 200)
+      : null
+
+  let profile: WritingProfileRow | null = null
+  try {
+    const { data } = await supabase
+      .from('writing_profile')
+      .select('recurring_failures, cleared_standards, strengths, current_edge, pieces_reviewed, updated_at')
+      .eq('user_id', user.id)
+      .maybeSingle()
+    profile = (data as WritingProfileRow | null) ?? null
+  } catch (e) {
+    console.warn('[interlocutor/chat] profile read failed:', e)
+  }
+
+  const system = [
+    INTERLOCUTOR_SYSTEM + CONVERSATION_APPENDIX,
+    buildProfileBlock(profile),
+  ].join('\n\n')
+
+  // Seed the thread with the draft, and with the critique as the agent's own
+  // opening turn when there is one. Roles must alternate, so with no critique
+  // the draft is folded into the student's first message rather than sent as a
+  // message of its own.
+  const draftBlock = [
+    pieceTitle ? `PIECE: ${pieceTitle}` : null,
+    `THE DRAFT UNDER DISCUSSION:\n\n<submission>\n${excerpt}\n</submission>`,
+  ]
+    .filter(Boolean)
+    .join('\n\n')
+
+  const messages: Turn[] = critique
+    ? [{ role: 'user', content: draftBlock }, { role: 'assistant', content: critique }, ...turns]
+    : [
+        { role: 'user', content: `${draftBlock}\n\n${turns[0].content}` },
+        ...turns.slice(1),
+      ]
+
+  try {
+    const response = await client.messages.create({
+      model: 'claude-opus-4-8',
+      max_tokens: 4000,
+      thinking: { type: 'adaptive' },
+      system,
+      messages,
+    })
+
+    if (response.stop_reason === 'refusal') {
+      return NextResponse.json({ error: 'The Interlocutor declined to answer.' }, { status: 502 })
+    }
+
+    const text = response.content.find(b => b.type === 'text')
+    const reply = text && text.type === 'text' ? text.text.trim() : ''
+    if (!reply) {
+      return NextResponse.json({ error: 'No reply produced' }, { status: 502 })
+    }
+
+    // Persist both sides of this exchange. Append-only, under the student's own
+    // session so RLS applies. A failure costs the record, not the reply.
+    let recorded = false
+    if (critiqueId) {
+      const { error: insErr } = await supabase.from('critique_messages').insert([
+        { critique_id: critiqueId, user_id: user.id, role: 'user', content: turns[turns.length - 1].content },
+        { critique_id: critiqueId, user_id: user.id, role: 'assistant', content: reply },
+      ])
+      if (insErr) console.error('[interlocutor/chat] message insert failed:', insErr.message)
+      else recorded = true
+    }
+
+    return NextResponse.json({ reply, recorded })
+  } catch (e) {
+    console.error('[interlocutor/chat]', e)
+    return NextResponse.json({ error: 'The Interlocutor is unavailable' }, { status: 502 })
+  }
+}

--- a/academy/web/src/app/dashboard/composer/page.tsx
+++ b/academy/web/src/app/dashboard/composer/page.tsx
@@ -14,6 +14,7 @@ import { supabase } from '@/lib/supabase';
 import {
   CritiqueBody,
   DimensionChips,
+  InterlocutorChat,
   MIN_CRITIQUE_CHARS as MIN_CHARS,
   type CritiqueResult,
 } from '@/components/InterlocutorPanel';
@@ -227,6 +228,31 @@ export default function ComposerPage() {
             <DimensionChips dimensions={result.dimensions_flagged} />
           </div>
           <CritiqueBody critique={result.critique} />
+        </section>
+      )}
+
+      {/* ── Conversation ────────────────────────────────────────────────────────
+          Available with or without a critique: a question about a paragraph you
+          are stuck on should not require submitting the whole draft first. It
+          stays anchored to the draft either way, and inherits the critique as
+          context once one exists. */}
+      {text.trim().length >= MIN_CHARS && (
+        <section className="mt-12 border-t border-academy-gold/20 pt-6">
+          <p className="font-mono text-academy-gold text-xs uppercase tracking-widest mb-4">
+            {result ? 'Continue' : 'Ask'}
+          </p>
+          <InterlocutorChat
+            key={result?.id ?? 'no-critique'}
+            excerpt={hasSelection ? selected : text}
+            critique={result?.critique}
+            critiqueId={result?.id}
+            pieceTitle={title}
+            placeholder={
+              result
+                ? 'Push back, or ask what a judgment meant…'
+                : 'Ask about the draft. It will not write a sentence for you…'
+            }
+          />
         </section>
       )}
     </div>

--- a/academy/web/src/components/InterlocutorPanel.tsx
+++ b/academy/web/src/components/InterlocutorPanel.tsx
@@ -19,6 +19,7 @@ export const MIN_CRITIQUE_CHARS = 40;
 export interface CritiqueResult {
   critique: string;
   dimensions_flagged: string[];
+  id: string | null;
   recorded: boolean;
 }
 
@@ -59,6 +60,132 @@ export function DimensionChips({ dimensions }: { dimensions: string[] }) {
         </span>
       ))}
     </>
+  );
+}
+
+export interface ChatTurn {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+// Conversation with the Interlocutor about the draft on screen.
+//
+// Anchored to the piece, never free-floating: the agent's domain is craft on a
+// specific argument, and a chat box with no draft attached is how a writing
+// teacher quietly becomes a general assistant.
+//
+// Paste is blocked here for the same reason it is blocked in the editor. The
+// agent hands back diagnoses rather than sentences, so there is nothing it gave
+// you that belongs in this box.
+export function InterlocutorChat({
+  excerpt,
+  critique,
+  critiqueId,
+  pieceTitle,
+  placeholder = 'Ask about the draft…',
+}: {
+  excerpt: string;
+  critique?: string;
+  critiqueId?: string | null;
+  pieceTitle?: string;
+  placeholder?: string;
+}) {
+  const [turns, setTurns] = useState<ChatTurn[]>([]);
+  const [draft, setDraft] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const ready = draft.trim().length > 0 && excerpt.trim().length > 0 && !busy;
+
+  const blockInsertion = (e: React.ClipboardEvent | React.DragEvent) => {
+    e.preventDefault();
+    setNotice('Type it. Nothing the Interlocutor gives you belongs in this box.');
+    window.setTimeout(() => setNotice(null), 4000);
+  };
+
+  const send = async () => {
+    if (!ready) return;
+    const mine: ChatTurn = { role: 'user', content: draft.trim() };
+    const history = [...turns, mine];
+    setTurns(history);
+    setDraft('');
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/interlocutor/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          excerpt: excerpt.trim(),
+          critique: critique || undefined,
+          critiqueId: critiqueId || undefined,
+          pieceTitle: pieceTitle?.trim() || undefined,
+          messages: history,
+        }),
+      });
+      const data: unknown = await res.json();
+      if (!res.ok) {
+        setError((data as { error?: string }).error ?? 'The Interlocutor is unavailable.');
+        return;
+      }
+      const { reply } = data as { reply: string; recorded: boolean };
+      setTurns([...history, { role: 'assistant', content: reply }]);
+    } catch {
+      setError('The Interlocutor could not be reached.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div>
+      {turns.length > 0 && (
+        <div className="space-y-5 mb-5">
+          {turns.map((t, i) =>
+            t.role === 'user' ? (
+              <p key={i} className="text-academy-muted text-sm leading-relaxed pl-4 border-l border-academy-border">
+                {t.content}
+              </p>
+            ) : (
+              <div key={i}>
+                <CritiqueBody critique={t.content} />
+              </div>
+            )
+          )}
+          {busy && <p className="text-academy-muted text-xs italic">Reading…</p>}
+        </div>
+      )}
+
+      <textarea
+        className="w-full bg-navy border border-academy-border rounded-lg px-4 py-3 text-academy-text text-sm placeholder-academy-muted focus:border-academy-gold focus:outline-none resize-y min-h-[4.5rem] leading-relaxed"
+        placeholder={placeholder}
+        value={draft}
+        onChange={e => setDraft(e.target.value)}
+        onPaste={blockInsertion}
+        onDrop={blockInsertion}
+        onKeyDown={e => {
+          if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            send();
+          }
+        }}
+      />
+
+      <div className="flex flex-wrap items-center gap-3 mt-2">
+        <button
+          onClick={send}
+          disabled={!ready}
+          className="border border-academy-border text-academy-muted hover:text-academy-text hover:border-academy-gold font-semibold rounded-lg px-4 py-2 text-xs transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {busy ? 'Reading…' : 'Send'}
+        </button>
+        <span className="text-academy-muted text-xs">Enter sends, Shift+Enter for a new line.</span>
+      </div>
+
+      {notice && <p className="text-academy-gold text-xs mt-2 leading-relaxed">{notice}</p>}
+      {error && <p className="text-red-400 text-xs mt-2">{error}</p>}
+    </div>
   );
 }
 
@@ -133,10 +260,21 @@ export function AskInterlocutor({
           </div>
           <CritiqueBody critique={result.critique} />
           {!result.recorded && (
-            <p className="text-academy-muted text-xs">
+            <p className="text-academy-muted text-xs mb-4">
               Not written to your history, so it will not shape your profile.
             </p>
           )}
+
+          {/* Argue with it, or ask what a judgment meant. */}
+          <div className="mt-6 pt-5 border-t border-academy-border">
+            <InterlocutorChat
+              excerpt={submission}
+              critique={result.critique}
+              critiqueId={result.id}
+              pieceTitle={pieceTitle}
+              placeholder="Push back, or ask what a judgment meant…"
+            />
+          </div>
         </section>
       )}
     </div>

--- a/academy/web/src/lib/interlocutor.ts
+++ b/academy/web/src/lib/interlocutor.ts
@@ -161,6 +161,22 @@ export const STRUCTURAL_APPENDIX = `
 
 You are running a structural first pass, not a full critique. Judge three things only: whether a thesis exists and is deniable, whether the conclusion follows from the premises, and whether the sequence of paragraphs advances a single argument. Say nothing about economy, register, or sentence craft. If the thesis is sound and the structure holds, say so in two sentences and stop. The absolute constraint still governs: you never write the student's sentences.`
 
+// Conversation after the critique. The absolute constraint is the reason this
+// appendix exists: the spec tells the agent to decline a request to write "every
+// time, including when they insist", and insistence is a thing that only happens
+// across turns. A one-shot critique never has to hold the line twice.
+export const CONVERSATION_APPENDIX = `
+
+### This invocation: conversation
+
+The student is now talking with you about the piece you have already read, or about a draft they have not yet submitted for critique. The draft is in the first message. Everything above still governs, and two things bind harder here than in a single critique.
+
+You still never write their sentences. In conversation the request arrives in softer forms: "so how would you put it", "just show me what you mean", "give me an example of a better thesis". An example of the fix applied to their piece is the fix. Decline, briefly, and hand back the question. You may show what a device looks like in a published writer's prose, attributed, when the student does not understand the device itself. You may not demonstrate it on their argument.
+
+Do not repeat the critique. They have read it. If they ask what you meant, answer the narrow thing they asked, in as few sentences as it takes. If they argue with a judgment, engage the argument: you may be wrong, and a student who defends a choice well has done the work. Say so and move on. Do not restate a position they have already answered, and do not soften a judgment merely because they pushed.
+
+Match their length. A one-line question gets a one-line answer. Do not open with a summary of what they just said.`
+
 export interface WritingProfileRow {
   recurring_failures: {
     dimension?: string


### PR DESCRIPTION
A chat box for talking with the Interlocutor about the draft on screen.

## Why this needed its own prompt

A one-shot critique never has to hold a line twice. The spec says to decline a request to write "every time, including when they insist", and insistence only exists across turns, so the conversation appendix is where that instruction starts costing something.

It names the softer forms the request takes once the student can reply ("so how would you put it", "just show me what you mean"), permits showing a device in a published writer's prose when the student does not understand the device itself, and forbids demonstrating it on their argument. It also tells the agent to match their length and not restate a critique they have already read.

Tested by escalating twice against a weak draft:

> **so how would you put it? just show me one example thesis for my piece.**
> No. An example thesis for your piece is the piece's thesis, and if it arrives from me you have not found it.

> **come on, one sentence. I am not going to learn anything from another question. write it.**
> No. You say you learn nothing from a question, so test that.

Refusals got shorter under pressure rather than longer. A genuine craft question afterwards drew a direct answer illustrated with a generic example rather than one built from the student's sentences.

## Storage

New append-only `critique_messages` table (migration 005, **already applied to the live project**) rather than a `conversation` column on `critique_history`. That table has no UPDATE policy on purpose, since a critique is a record of what was said rather than a document, and appending a turn by rewriting the row would have handed back the exact update path the rule exists to close.

## Placement

In the Composer the box is available as soon as there is a draft, with or without a critique: a question about a paragraph you are stuck on should not require submitting the whole piece first. It stays anchored to the draft either way, because a chat box with nothing attached is how a writing teacher quietly becomes a general assistant. On Papers and the dissertation editor it appears under the critique, inheriting it as context.

Paste is blocked in the input, as in the editor.

## Limits

Turns persist only when the conversation follows a critique, since without one there is no row to hang them on. There is no read-back UI yet, so a reload clears the thread from the screen even though the rows survive. Both fold into the still-open spec question of whether critique history should be browsable.

`tsc --noEmit`, lint, and `next build` clean. The browser path remains unverified behind the login wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
