### PR TITLE
fix(academy): group the sidebar, and stop the chat vanishing without explanation

### DIFF
--- a/academy/web/src/app/dashboard/composer/page.tsx
+++ b/academy/web/src/app/dashboard/composer/page.tsx
@@ -236,11 +236,11 @@ export default function ComposerPage() {
           are stuck on should not require submitting the whole draft first. It
           stays anchored to the draft either way, and inherits the critique as
           context once one exists. */}
-      {text.trim().length >= MIN_CHARS && (
-        <section className="mt-12 border-t border-academy-gold/20 pt-6">
-          <p className="font-mono text-academy-gold text-xs uppercase tracking-widest mb-4">
-            {result ? 'Continue' : 'Ask'}
-          </p>
+      <section className="mt-12 border-t border-academy-gold/20 pt-6">
+        <p className="font-mono text-academy-gold text-xs uppercase tracking-widest mb-4">
+          {result ? 'Continue' : 'Ask'}
+        </p>
+        {text.trim().length >= MIN_CHARS ? (
           <InterlocutorChat
             key={result?.id ?? 'no-critique'}
             excerpt={hasSelection ? selected : text}
@@ -253,8 +253,15 @@ export default function ComposerPage() {
                 : 'Ask about the draft. It will not write a sentence for you…'
             }
           />
-        </section>
-      )}
+        ) : (
+          // The heading stays even when the box cannot. Hiding the section
+          // outright left nothing on the page to explain the absence.
+          <p className="text-academy-muted text-sm leading-relaxed">
+            The conversation is anchored to the draft, so it opens once there is
+            a draft to anchor it to. Write a few sentences above.
+          </p>
+        )}
+      </section>
     </div>
   );
 }

--- a/academy/web/src/components/navigation/Sidebar.tsx
+++ b/academy/web/src/components/navigation/Sidebar.tsx
@@ -4,20 +4,56 @@ import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabase';
 
-const navItems = [
-  { href: '/dashboard',            label: 'Dashboard',    icon: '🏛️' },
-  { href: '/dashboard/courses',    label: 'Courses',      icon: '📚' },
-  { href: '/dashboard/lexicon',    label: 'Lexicon',      icon: '𝛼' },
-  { href: '/dashboard/drill',      label: 'Vocab Drill',  icon: '🏺' },
-  { href: '/dashboard/examine',    label: 'Daily Examination', icon: '☀️' },
-  { href: '/dashboard/practicum',  label: 'Practicum',    icon: '🔥' },
-  { href: '/dashboard/courtyard',  label: 'The Courtyard', icon: '⚗️' },
-  { href: '/dashboard/library',    label: 'Library',      icon: '📜' },
-  { href: '/dashboard/papers',     label: 'Papers',       icon: '✒️' },
-  { href: '/dashboard/composer',   label: 'Composer',     icon: '🖋️' },
-  { href: '/dashboard/dissertation', label: 'Dissertation', icon: '🎓' },
-  { href: '/dashboard/profile',    label: 'Profile',      icon: '👤' },
+// Twelve destinations is past the point where a flat list can be scanned, and
+// whatever sits at the bottom falls below the fold on a laptop. Grouped, with
+// the writing surfaces together and the Composer at the head of them.
+const navSections: { heading: string | null; items: NavItem[] }[] = [
+  {
+    heading: null,
+    items: [{ href: '/dashboard', label: 'Dashboard', icon: '🏛️', mobile: true }],
+  },
+  {
+    heading: 'Study',
+    items: [
+      { href: '/dashboard/courses', label: 'Courses',     icon: '📚', mobile: true },
+      { href: '/dashboard/lexicon', label: 'Lexicon',     icon: '𝛼' },
+      { href: '/dashboard/drill',   label: 'Vocab Drill', icon: '🏺' },
+    ],
+  },
+  {
+    heading: 'Practice',
+    items: [
+      { href: '/dashboard/examine',   label: 'Daily Examination', icon: '☀️' },
+      { href: '/dashboard/practicum', label: 'Practicum',         icon: '🔥' },
+      { href: '/dashboard/courtyard', label: 'The Courtyard',     icon: '⚗️' },
+    ],
+  },
+  {
+    heading: 'Write',
+    items: [
+      { href: '/dashboard/composer',     label: 'Composer',     icon: '🖋️', mobile: true },
+      { href: '/dashboard/papers',       label: 'Papers',       icon: '✒️' },
+      { href: '/dashboard/dissertation', label: 'Dissertation', icon: '🎓' },
+    ],
+  },
+  {
+    heading: 'Reference',
+    items: [
+      { href: '/dashboard/library', label: 'Library', icon: '📜', mobile: true },
+      { href: '/dashboard/profile', label: 'Profile', icon: '👤', mobile: true },
+    ],
+  },
 ];
+
+interface NavItem {
+  href: string;
+  label: string;
+  icon: string;
+  // Twelve tabs in a bottom bar is five pixels each. Only these ride along.
+  mobile?: boolean;
+}
+
+const mobileItems = navSections.flatMap(s => s.items).filter(i => i.mobile);
 
 interface SidebarProps {
   navOpen: boolean;
@@ -60,20 +96,29 @@ export default function Sidebar({ navOpen, onToggle }: SidebarProps) {
           </button>
         </div>
 
-        <nav className="flex-1 py-4 overflow-y-auto">
-          {navItems.map(item => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className={`flex items-center gap-3 px-6 py-3 text-sm transition-colors ${
-                isActive(item.href)
-                  ? 'text-academy-gold bg-academy-bg border-r-2 border-academy-gold'
-                  : 'text-academy-muted hover:text-academy-text hover:bg-academy-bg'
-              }`}
-            >
-              <span className="text-base">{item.icon}</span>
-              <span className="font-medium">{item.label}</span>
-            </Link>
+        <nav className="flex-1 py-3 overflow-y-auto">
+          {navSections.map((section, i) => (
+            <div key={section.heading ?? `section-${i}`} className={section.heading ? 'mt-4' : ''}>
+              {section.heading && (
+                <p className="px-6 pb-1.5 font-mono text-[10px] uppercase tracking-[0.2em] text-academy-muted/60">
+                  {section.heading}
+                </p>
+              )}
+              {section.items.map(item => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={`flex items-center gap-3 px-6 py-2.5 text-sm transition-colors ${
+                    isActive(item.href)
+                      ? 'text-academy-gold bg-academy-bg border-r-2 border-academy-gold'
+                      : 'text-academy-muted hover:text-academy-text hover:bg-academy-bg'
+                  }`}
+                >
+                  <span className="text-base">{item.icon}</span>
+                  <span className="font-medium">{item.label}</span>
+                </Link>
+              ))}
+            </div>
           ))}
         </nav>
 
@@ -93,10 +138,10 @@ export default function Sidebar({ navOpen, onToggle }: SidebarProps) {
         </div>
       </aside>
 
-      {/* Mobile Bottom Nav — unchanged */}
+      {/* Mobile Bottom Nav — the five that survive a phone-width bar. */}
       <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-academy-surface border-t border-academy-border z-50">
         <div className="flex">
-          {navItems.map(item => (
+          {mobileItems.map(item => (
             <Link
               key={item.href}
               href={item.href}


### PR DESCRIPTION
Two problems the Composer surfaced, both introduced by the Interlocutor work.

## The sidebar

The nav had eleven flat items and #123 made it twelve. A flat twelve cannot be scanned, and whatever lands at the bottom falls below the fold on a laptop, so the Composer entry was present but effectively invisible. The list already had `overflow-y-auto`, so a scrollbar was never the missing piece. Structure was.

Four labelled groups now, with Dashboard ungrouped at the top and tighter rows:

- **Study** — Courses, Lexicon, Vocab Drill
- **Practice** — Daily Examination, Practicum, The Courtyard
- **Write** — Composer, Papers, Dissertation
- **Reference** — Library, Profile

The Composer heads the Write group rather than trailing after Papers, since it is the blank page.

Separately: the mobile bottom bar was rendering all twelve items in a `flex-1` row, a few pixels per tab. That was already broken at eleven, before the Composer was added. It now carries five, marked with a `mobile` flag on the items rather than a second hand-maintained list.

## The chat that was not there

The conversation section rendered only above forty characters of draft, so an empty Composer showed no chat box and nothing at all to explain the absence. Anyone looking for a feature they had just been told about would reasonably conclude it had not shipped.

The heading stays now, and below the threshold it says the conversation is anchored to the draft and opens once there is one. The threshold itself is right: an unanchored chat box is how a writing teacher quietly becomes a general assistant.

## Verification

`tsc --noEmit`, lint, and `next build` clean.

Not verified visually. Both changes are behind the login wall, so "grouped and fits above the fold" is reasoning about markup rather than something observed. The Vercel preview on this PR is the place to check it, and if the grouping reads as clutter rather than structure, it flattens back easily.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
