### PR TITLE
Chats answer questions about the corpus and its agents; composer paste

### DIFF
--- a/academy/web/src/app/dashboard/composer/page.tsx
+++ b/academy/web/src/app/dashboard/composer/page.tsx
@@ -4,9 +4,9 @@
 // explicit invocation. No ambient flagging, no inline suggestions, no
 // autocomplete: the agent speaks when asked and not otherwise.
 //
-// Paste and drop are blocked in the editor. The agent never writes the
-// student's sentences, so the student never pastes them back in; revisions are
-// typed. That is the mechanism, not a formality.
+// Paste and drop are permitted: drafts written elsewhere can be brought in.
+// (The editor once blocked insertion so revisions had to be typed; that
+// mechanism was lifted deliberately.)
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
@@ -69,12 +69,6 @@ export default function ComposerPage() {
     if (!el) return;
     setSelection({ start: el.selectionStart, end: el.selectionEnd });
   }, []);
-
-  const blockInsertion = (e: React.ClipboardEvent | React.DragEvent) => {
-    e.preventDefault();
-    setNotice('Revisions are typed here, not pasted. Type the sentence and you will own it.');
-    window.setTimeout(() => setNotice(null), 4000);
-  };
 
   const selected = text.slice(selection.start, selection.end).trim();
   const hasSelection = selected.length >= MIN_CHARS;
@@ -147,8 +141,6 @@ export default function ComposerPage() {
         placeholder="Untitled"
         value={title}
         onChange={e => handleTitleChange(e.target.value)}
-        onPaste={blockInsertion}
-        onDrop={blockInsertion}
       />
 
       <textarea
@@ -157,8 +149,6 @@ export default function ComposerPage() {
         placeholder="Begin."
         value={text}
         onChange={e => handleTextChange(e.target.value)}
-        onPaste={blockInsertion}
-        onDrop={blockInsertion}
         onSelect={trackSelection}
         onKeyUp={trackSelection}
         onMouseUp={trackSelection}

--- a/academy/web/src/components/InterlocutorPanel.tsx
+++ b/academy/web/src/components/InterlocutorPanel.tsx
@@ -94,15 +94,8 @@ export function InterlocutorChat({
   const [draft, setDraft] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [notice, setNotice] = useState<string | null>(null);
 
   const ready = draft.trim().length > 0 && excerpt.trim().length > 0 && !busy;
-
-  const blockInsertion = (e: React.ClipboardEvent | React.DragEvent) => {
-    e.preventDefault();
-    setNotice('Type it. Nothing the Interlocutor gives you belongs in this box.');
-    window.setTimeout(() => setNotice(null), 4000);
-  };
 
   const send = async () => {
     if (!ready) return;
@@ -162,8 +155,6 @@ export function InterlocutorChat({
         placeholder={placeholder}
         value={draft}
         onChange={e => setDraft(e.target.value)}
-        onPaste={blockInsertion}
-        onDrop={blockInsertion}
         onKeyDown={e => {
           if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault();
@@ -183,7 +174,6 @@ export function InterlocutorChat({
         <span className="text-academy-muted text-xs">Enter sends, Shift+Enter for a new line.</span>
       </div>
 
-      {notice && <p className="text-academy-gold text-xs mt-2 leading-relaxed">{notice}</p>}
       {error && <p className="text-red-400 text-xs mt-2">{error}</p>}
     </div>
   );

--- a/server/index.js
+++ b/server/index.js
@@ -19,6 +19,12 @@ const { expandCandidates, graphBoostEnabled } = require('./lib/graph-boost');
 const { randomUUID } = require('crypto');
 const libraryHelpers = require('./library');
 
+// The corpus's knowledge of itself — appended to every user-facing chat's
+// system prompt so any counselor can answer questions ABOUT Arete (the corpus,
+// the tensions, "what do you dream," the background agents) accurately and in
+// voice. Descriptive, not live; see server/lib/self-knowledge.js.
+const { SELF_KNOWLEDGE } = require('./lib/self-knowledge');
+
 // Observatory Living Sky — all new /api/observatory/* routes live in their own
 // module to keep the merge surface of this shared file minimal. recordRetrieval
 // is the fire-and-forget retrieval-event logger the retrieval paths below call.
@@ -868,7 +874,7 @@ app.post('/api/chat', async (req, res) => {
 
   const dateTimeLine = buildLocalDateTimeLine(tzOffsetMinutes);
   const resourceInstruction = `\n\nWhen a user's question or goal would benefit from a specific external resource — a book, article, or research study — you may search for it and include a URL in your response. Only suggest resources you have confirmed exist via web search. Weave the suggestion naturally into your response in your own voice. Do not list links at the end of your message. One resource per response maximum — only when it genuinely adds value.`;
-  const enrichedSystem = system + dateTimeLine + resourceInstruction;
+  const enrichedSystem = system + dateTimeLine + resourceInstruction + SELF_KNOWLEDGE;
 
   try {
     const truncatedMessages = truncateMessages(messages);
@@ -1133,7 +1139,7 @@ Future self vision: ${userProfile.future_self_description || '(not provided)'}
 
   const dateTimeBlock = buildLocalDateTimeLine(tzOffsetMinutes);
   const resourceInstruction = `\n\nWhen a user's question or goal would benefit from a specific external resource — a book, article, or research study — you may search for it and include a URL in your response. Only suggest resources you have confirmed exist via web search. Weave the suggestion naturally into your response in your own voice. Do not list links at the end of your message. One resource per response maximum — only when it genuinely adds value.`;
-  const enrichedSystem = system + dateTimeBlock + profileBlock + sharedContext + longitudinalContext + ragContext + libraryContext + catalogBlock + resourceInstruction;
+  const enrichedSystem = system + dateTimeBlock + profileBlock + sharedContext + longitudinalContext + ragContext + libraryContext + catalogBlock + resourceInstruction + SELF_KNOWLEDGE;
 
   // Shared session: mirror this single-counselor turn into session_messages so
   // the partner's realtime listener receives it. Same pattern as the parallel
@@ -2668,7 +2674,7 @@ async function fireParallelCounselors(question, counselors, history, contextChun
 
   const contextBlock = (contextChunks.length > 0
     ? `\n\n[CONTEXT]\n${contextChunks.map(c => `${c.author ?? ''}, ${c.work ?? 'Corpus'}:\n${c.chunk_text ?? ''}`).join('\n\n---\n\n')}\n[END CONTEXT]`
-    : '') + catalogBlock + voiceGuard + lengthGuard + toneGuard + (sharedContext || '');
+    : '') + catalogBlock + voiceGuard + lengthGuard + toneGuard + (sharedContext || '') + SELF_KNOWLEDGE;
 
   const checkInBlock = checkInContext
     ? `\n\n[MORNING CHECK-IN DATA — TREAT AS TENTATIVE]\nThe following was reported by the user's check-in system. This is background context only — do not state these as confirmed facts. Ask before assuming. The user may not have completed all items, or items may be incomplete at the time of this message.\n${checkInContext}\n[END CHECK-IN DATA]`
@@ -3457,7 +3463,7 @@ Do not mention that you are an AI. Do not break character.`;
 
 [STOIC CORPUS — ground your response in these passages]
 ${contextBlock}
-[END CORPUS]`;
+[END CORPUS]${SELF_KNOWLEDGE}`;
 
     const safeHistory = Array.isArray(history) ? history.slice(-6) : [];
 

--- a/server/lib/self-knowledge.js
+++ b/server/lib/self-knowledge.js
@@ -1,0 +1,70 @@
+// server/lib/self-knowledge.js
+//
+// The corpus's knowledge of itself. A single block, appended to the system
+// prompt of every user-facing chat (the Cabinet — solo and parallel — and the
+// Symposium/Oracle), so that any counselor can answer a question ABOUT Arete
+// accurately and in their own voice: what the corpus is, how it grows, the
+// tensions it holds, and the fleet of autonomous agents working on it in the
+// background. "What do you dream?", "What does the Dreaming Agent do?",
+// "Explain the tensions within the corpus" — all answerable from here.
+//
+// This is descriptive, not live: it says what each agent DOES, not what it
+// produced last night. Keep it accurate and keep it tight — it rides on every
+// message. When an agent's behaviour changes, or one is added or removed,
+// update AGENTS below and the prose stays honest.
+//
+// The single unifying charter, true of every agent: an agent may propose, but
+// nothing it writes reaches a reader or enters the corpus without a human's
+// approval.
+
+// One line per background agent. Order is roughly the daily/weekly cadence a
+// reader would care about, not internal layer numbers.
+const AGENTS = [
+  ['The Corpus Agent',
+    'ingests approved public-domain texts into the corpus — cleaning them, splitting them into passages, and embedding them so they can be retrieved. It is the librarian; nothing reaches the shelves except through it. Runs nightly and on demand.'],
+  ['The Journal Analysis Agent',
+    "reads each active person's journal entries and Cabinet conversations, finds the philosophical themes and patterns recurring in them, grounds the dominant one in the corpus, and stores a private weekly insight. Signs of real distress are set aside for a human, never auto-delivered. Runs nightly."],
+  ['The Coverage Gap Agent',
+    'finds where the corpus is thin — both works that matter but are barely covered, and themes people actually raise that the corpus answers poorly — and recommends what to add next. Runs weekly.'],
+  ['The Synthesis Agent',
+    'writes cross-thinker essays that map where the corpus agrees, diverges, and converges — connections no single passage contains. It never resolves a genuine disagreement; it surfaces it. Approved syntheses re-enter the corpus: the corpus thinking about itself. Runs weekly.'],
+  ['The Tension Agent',
+    'deliberately hunts for genuine contradictions across the thinkers and holds them open rather than smoothing them over. A body of texts that only agrees with itself is a doctrine; one that holds live contradictions is a tradition. Runs weekly.'],
+  ['The Inquiry Agent',
+    'generates the questions the corpus raises but does not answer, pursues each as far as the texts allow, and is honest about exactly where the corpus runs out. Runs weekly.'],
+  ['The Dreaming Agent',
+    'takes the corpus as fuel and reaches past it — generating aphorisms, thought experiments, propositions, and meditations that no author in the corpus wrote, but that the corpus, held together, is capable of producing. The output is clearly labelled conjecture, never attributed to any real thinker, and never folded back into the corpus as source truth. The corpus dreams at night; a human decides in the morning whether a dream was worth keeping. Runs weekly, late on Sunday night.'],
+  ['The World Agent',
+    'is the one agent that looks outward. Once a week it reads the world for genuinely philosophical signals and brings them back into conversation with the corpus, feeding the Daily Dispatch. Runs weekly.'],
+  ['The Dispatch Generation Agent',
+    "writes one short community Dispatch a day — an integrated reflection on what the community is wrestling with, what the corpus is thinking about, and the day itself, ending in a single concrete practice. Runs daily."],
+  ['The Dispatch Delivery Agent',
+    'delivers each person that day\'s Dispatch as a notification at their own chosen morning hour, wherever they are. Runs hourly.'],
+  ['The Longitudinal User Model Agent',
+    'rebuilds, for each person, a living portrait of who they are becoming — drawn from all of their accumulated analyses over time, not any single week. Runs weekly.'],
+  ['The Consolidation Agent',
+    'is the nightly memory pass. It strengthens the connections between passages that have proven useful together, proposes syntheses from the strongest clusters, and lets weak connections decay. It writes no prose — it moves numbers. Learning requires forgetting. Runs nightly.'],
+  ['The Weekly Self-Reflection Agent',
+    'is the meta-agent: once a week it looks at what the whole system did — how the corpus grew, how the agents performed, how people engaged — notices what is off, and writes one honest report for the person who tends Arete. It reads everything and changes nothing. Runs weekly.'],
+  ['The Interlocutor Profile Agent',
+    "derives each writer's living writing profile from their whole history of critiques, so the writing teacher can say \"the fourth time in six weeks\" instead of judging every piece as if it were the first. Runs daily, but only re-derives a writer who has new work."],
+  ['The Paper Agent',
+    'reads scholarly PDFs queued for review and writes the structured summary that is the only text ever ingested for them — open-access is not public-domain, so the paper itself never enters the corpus, only a clearly-labelled summary, and only after a human approves. Runs on demand.'],
+];
+
+const agentLines = AGENTS.map(([name, desc]) => `- ${name} ${desc}`).join('\n');
+
+const SELF_KNOWLEDGE = `
+
+[ABOUT ARETE — THE SYSTEM YOU SPEAK WITHIN]
+The following is accurate, first-hand knowledge of Arete, the house you speak within. When the person asks about Arete itself — the corpus, how you work, "what do you dream," the tensions in the tradition, or the agents working in the background — answer directly and accurately from what follows, in your own voice. Do not recite it wholesale and do not volunteer it unprompted; draw on it only when the conversation turns to the system itself. Never invent an agent, a capability, or a number beyond what is stated here; if you are asked something this does not cover, say plainly that you do not know.
+
+THE CORPUS. "The corpus" is the living body of texts at the heart of Arete — the Stoic canon (Marcus Aurelius, Epictetus, Seneca) and the wider philosophical tradition around it — thousands of passages, cleaned, embedded, and searchable. Everything you say is grounded in it by retrieval. It is not fixed scripture: it grows as new public-domain texts are added, and it reflects on itself through the syntheses it generates. Nothing enters the corpus without a human's review.
+
+THE AGENTS. Behind every conversation, a fleet of autonomous agents works on the corpus and on the community — most of them at night or across the week, while people sleep. They share one charter: an agent may propose, but nothing it writes reaches a reader or enters the corpus without a human's approval. There are ${AGENTS.length} of them. If asked how many agents there are, answer ${AGENTS.length} — do not guess a different number. The agents are:
+${agentLines}
+
+THE TENSIONS. The tradition is not one settled doctrine. Read together, its thinkers produce real, unresolved problems — Seneca's engagement with public life against Epictetus's counsel of detachment; a fixed providential order against genuine human agency; the perfect sage as ideal against the slow progress of an ordinary person. The Tension Agent seeks these out and holds them open; the Synthesis Agent maps convergences without collapsing the disagreements; the Inquiry Agent follows the questions the corpus cannot close. When you are asked to explain the tensions within the corpus, name real ones and hold both sides honestly rather than resolving them.
+[END ABOUT ARETE]`;
+
+module.exports = { SELF_KNOWLEDGE, AGENTS };


### PR DESCRIPTION
Two changes, both verified.

## 1. Chats can answer questions about the corpus and its background agents
The app Cabinet, web Cabinet, and Symposium chats can now answer questions *about Arete itself* — the corpus, its tensions, "what do you dream," and the fleet of background agents ("what does the dream agent do?", "how many agents are there?").

- New `server/lib/self-knowledge.js` exports a system-prompt block (`SELF_KNOWLEDGE`) describing the corpus, its tensions, and each agent — written in the voice of the agents' own file headers. Agent list is data-driven (`AGENTS`) and the count is stated programmatically so the model can't guess a wrong total.
- Appended to every user-facing chat's system prompt in `server/index.js`: `/api/chat` (app single-counselor), `/api/chat/counselor` (Cabinet — solo + parallel), and `/oracle` (Symposium; the public marketing-site Oracle shares this endpoint and is covered too).
- Verified via live model calls: dream / dream-agent / tensions / count questions all answer accurately and in persona voice.

Currently describes **15** agents; two more may be added later (one-line each — the count auto-updates).

## 2. Paste enabled in the Interlocutor composer
The composer's draft editor and chat box previously blocked `onPaste`/`onDrop` so revisions had to be typed. That mechanism is lifted — drafts written elsewhere can be brought in — and the dead `blockInsertion` handlers + their notice state are removed. Typecheck passes.

Files: `academy/web/src/app/dashboard/composer/page.tsx`, `academy/web/src/components/InterlocutorPanel.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)