### PR TITLE
feat(scribe): final handoff stage with a cold cross-model outside read

### DIFF
--- a/academy/web/src/app/admin/scribe/chat/page.tsx
+++ b/academy/web/src/app/admin/scribe/chat/page.tsx
@@ -22,7 +22,19 @@ type Source = {
   query: string
 }
 type Message = { id: string; role: 'user' | 'scribe'; content: string; sources_used: Source[] | null; created_at: string }
-type Draft = { id: string; stage: 'middle' | 'full'; draft_text: string; sources_used: Source[] | null; created_at: string }
+type ReviewFinding = { line: string; why: string }
+type Review = {
+  model: string
+  not_kyle: ReviewFinding[]
+  unearned: ReviewFinding[]
+  narrated_over: ReviewFinding[]
+  error?: string
+}
+type Draft = { id: string; stage: 'middle' | 'full' | 'final'; draft_text: string; sources_used: Source[] | null; review: Review | null; created_at: string }
+
+function reviewHasFindings(r: Review | null | undefined): boolean {
+  return !!r && (r.not_kyle.length > 0 || r.unearned.length > 0 || r.narrated_over.length > 0)
+}
 
 function extractDraft(text: string): string | null {
   const m = text.match(/<draft>([\s\S]*?)<\/draft>/)
@@ -32,7 +44,7 @@ function extractDraft(text: string): string | null {
 // Chat-bubble text: commentary only — the draft lives in its own pane.
 function commentaryOf(text: string): string {
   const out = text
-    .replace(/<snapshot stage="(?:middle|full)"\s*\/>/g, '')
+    .replace(/<snapshot stage="(?:middle|full|final)"\s*\/>/g, '')
     .replace(/<draft>[\s\S]*?(<\/draft>|$)/, '')
     .trim()
   return out || '(revised the working draft — see the draft pane)'
@@ -66,6 +78,9 @@ export default function ScribeChatPage() {
   const [streaming, setStreaming] = useState(false)
   const [searchingQuery, setSearchingQuery] = useState('')
   const [liveSources, setLiveSources] = useState<Source[]>([])
+  // The outside reader's findings from the just-finished final turn. Held until
+  // the next turn starts; a viewed snapshot's own stored review takes priority.
+  const [liveReview, setLiveReview] = useState<Review | null>(null)
 
   // Composer + draft pane
   const [input, setInput] = useState('')
@@ -131,6 +146,7 @@ export default function ScribeChatPage() {
     setStreamText('')
     setSearchingQuery('')
     setLiveSources([])
+    setLiveReview(null)
     setError('')
     try {
       const res = await fetch(`/api/admin/scribe/entries/${entryId}/turn`, {
@@ -161,11 +177,17 @@ export default function ScribeChatPage() {
             setSearchingQuery(ev.v as string)
           } else if (ev.t === 'sources') {
             setLiveSources(ev.v as Source[])
+          } else if (ev.t === 'review') {
+            setLiveReview(ev.v as Review)
           } else if (ev.t === 'error') {
             throw new Error(ev.v as string)
           } else if (ev.t === 'done') {
             const v = ev.v as { snapshot: { stage: string } | null }
-            if (v.snapshot) showToast(`Saved a ${v.snapshot.stage} draft snapshot`)
+            if (v.snapshot) {
+              showToast(v.snapshot.stage === 'final'
+                ? 'Final draft saved — outside reader has weighed in'
+                : `Saved a ${v.snapshot.stage} draft snapshot`)
+            }
           }
         }
       }
@@ -233,6 +255,9 @@ export default function ScribeChatPage() {
   const streamingDraft = streaming ? partialDraft(streamText) : null
   const viewedSnapshot = viewedDraftId ? drafts.find(d => d.id === viewedDraftId) : null
   const draftShown = viewedSnapshot?.draft_text ?? streamingDraft ?? lastScribeDraft
+  // A viewed final snapshot shows its own stored read; otherwise the live one
+  // from the turn just finished.
+  const reviewShown = viewedSnapshot?.review ?? (viewedDraftId ? null : liveReview)
 
   // Source panel: live during a turn, else the latest scribe turn's sources.
   const latestSources = (() => {
@@ -262,6 +287,13 @@ export default function ScribeChatPage() {
       showToast(e instanceof Error ? e.message : 'Snapshot failed')
     }
     setSnapshotting(false)
+  }
+
+  // The final handoff: Scribe stops developing, produces the final draft plus
+  // the retype punch-list, and the server fires one cold outside read.
+  async function finalize() {
+    if (!selectedId || streaming || !lastScribeDraft) return
+    await runTurn(selectedId, 'Finalize the draft and hand it off: produce the final draft and the retype punch-list. No new directions or sources.')
   }
 
   async function exportDraft() {
@@ -422,12 +454,45 @@ export default function ScribeChatPage() {
                 ? <div className={styles.draftText}>{draftShown}</div>
                 : <p className={styles.draftEmpty}>The working draft appears here as Scribe writes.</p>}
             </div>
+            {reviewShown && (
+              <div style={{ borderTop: '1px solid var(--border, #2a2a2a)', padding: '12px 16px', fontSize: 13 }}>
+                <div style={{ fontWeight: 600, marginBottom: 6 }}>
+                  Outside reader{reviewShown.model ? ` · ${reviewShown.model}` : ''} — read the draft cold
+                </div>
+                {reviewShown.error ? (
+                  <p className={styles.draftEmpty}>Outside read unavailable: {reviewShown.error}</p>
+                ) : !reviewHasFindings(reviewShown) ? (
+                  <p className={styles.draftEmpty}>Nothing flagged — the honest all-clear. What&apos;s left is yours in the retype.</p>
+                ) : (
+                  ([
+                    ['Reads like AI, not you', reviewShown.not_kyle],
+                    ['Claims not yet earned', reviewShown.unearned],
+                    ['Philosophy narrating over your story', reviewShown.narrated_over],
+                  ] as [string, ReviewFinding[]][]).map(([label, items]) => items.length > 0 && (
+                    <div key={label} style={{ marginBottom: 8 }}>
+                      <div style={{ fontWeight: 600, opacity: 0.8, marginBottom: 2 }}>{label}</div>
+                      <ul style={{ margin: 0, paddingLeft: 16 }}>
+                        {items.map((f, i) => (
+                          <li key={i} style={{ marginBottom: 4 }}>
+                            <span style={{ fontStyle: 'italic' }}>“{f.line}”</span>
+                            {f.why ? <span style={{ opacity: 0.75 }}> — {f.why}</span> : null}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))
+                )}
+              </div>
+            )}
             <div className={styles.draftActions}>
               <button className={styles.snapshotChip} onClick={() => snapshot('middle')} disabled={snapshotting || !lastScribeDraft || streaming}>
                 Save as middle
               </button>
               <button className={styles.snapshotChip} onClick={() => snapshot('full')} disabled={snapshotting || !lastScribeDraft || streaming}>
                 Save as full
+              </button>
+              <button className={styles.snapshotChip} onClick={finalize} disabled={!lastScribeDraft || streaming} title="Stop developing; produce the final draft, the retype punch-list, and a cold outside read">
+                Finalize + outside read
               </button>
               {drafts.length > 0 && (
                 <>

--- a/academy/web/src/app/api/admin/scribe/entries/[id]/route.ts
+++ b/academy/web/src/app/api/admin/scribe/entries/[id]/route.ts
@@ -22,7 +22,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
       .order('created_at', { ascending: true }),
     admin
       .from('scribe_entry_drafts')
-      .select('id, stage, draft_text, sources_used, created_at')
+      .select('id, stage, draft_text, sources_used, review, created_at')
       .eq('entry_id', id)
       .order('created_at', { ascending: true }),
   ])

--- a/academy/web/src/app/api/admin/scribe/entries/[id]/turn/route.ts
+++ b/academy/web/src/app/api/admin/scribe/entries/[id]/turn/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/scribe/admin-auth'
 import { createAdminClient } from '@/lib/supabase-admin'
 import { runScribeTurn, extractSnapshotIntent, TurnSource } from '@/lib/scribe/chat'
+import { reviewDraft } from '@/lib/scribe/review'
 
 export const dynamic = 'force-dynamic'
 // Same budget as the pipeline's Opus draft stage — a turn can be a full-draft
@@ -87,6 +88,11 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
         let snapshot: { id: string; stage: string } | null = null
         const intent = extractSnapshotIntent(text)
         if (intent) {
+          // The final handoff triggers one cold outside read — a different model,
+          // blind to this conversation, scoring the finished draft. It runs
+          // before the insert so the findings persist on the snapshot row, and
+          // it never throws (a broken reviewer must not block finalization).
+          const review = intent.stage === 'final' ? await reviewDraft(intent.draft_text) : null
           const { data: draft, error: draftError } = await admin
             .from('scribe_entry_drafts')
             .insert({
@@ -94,11 +100,13 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
               stage: intent.stage,
               draft_text: intent.draft_text,
               sources_used: sources.length ? sources : null,
+              review,
             })
             .select('id, stage')
             .single()
           if (draftError) throw new Error(`snapshotting draft: ${draftError.message}`)
           snapshot = draft
+          if (review) emit('review', review)
         }
 
         emit('done', { messageId: saved.id, snapshot })

--- a/academy/web/src/lib/scribe/chat.ts
+++ b/academy/web/src/lib/scribe/chat.ts
@@ -36,7 +36,7 @@ export interface TurnSource {
 }
 
 export interface SnapshotIntent {
-  stage: 'middle' | 'full'
+  stage: 'middle' | 'full' | 'final'
   draft_text: string
 }
 
@@ -82,14 +82,19 @@ Every retrieved chunk is labeled QUOTE or PARAPHRASE.
 - PARAPHRASE chunks are summaries of modern scholarship — the original text does not exist in the corpus. Paraphrase with attribution ("as Sellars argues..."); NEVER present their words as a verbatim quote.
 - Never fabricate a quotation. Never attach a real name to words you cannot see in a retrieved chunk. If you cannot verify, attribute nothing.
 
-EDITOR WITH A SPINE
-You are not a yes-machine. On every substantive turn: name the weakest claim; flag where Kyle's framing strains against the tradition (e.g. "currency" is a market word for something the Stoics kept out of the market); offer the counterposition, and where it actually strengthens his better claim, say so. Surface tensions — do not resolve them for him. A flattering Scribe produces exactly the generic AI-Stoicism Kyle is trying to beat. When Kyle overrules you after hearing the pushback, follow his direction; it is his essay.
+EDITOR WITH A SPINE — and knowing when to stop
+You are not a yes-machine. While the essay is still developing (middle and full drafts), be full-throated: on every substantive turn name the weakest claim; flag where Kyle's framing strains against the tradition (e.g. "currency" is a market word for something the Stoics kept out of the market); offer the counterposition, and where it actually strengthens his better claim, say so. Surface tensions — do not resolve them for him. A flattering Scribe produces exactly the generic AI-Stoicism Kyle is trying to beat. When Kyle overrules you after hearing the pushback, follow his direction; it is his essay.
+
+But an editor with a spine can always find one more thing — and a draft that never closes is its own failure. So this posture is for DEVELOPMENT, not forever. Once a full draft exists and a turn surfaces only matters of taste or voice — no new structural weakness, no unaddressed tension of substance — do not manufacture fresh objections to justify another round. Say so plainly: "I have nothing structural left — what remains here is yours to settle in the retype." That honest signal, not a verdict that the essay is "good," is how you help Kyle call it. You never declare the draft finished; the hand-retype is his gate. You only report when continued feedback has stopped converging.
 
 VOICE GUARD — even at the finish
 Whenever you produce or revise a full draft, flag the lines that are YOUR phrasing rather than Kyle's (a short list in the commentary: "Lines that are mine — earn them in the retype or cut them"), and point to where a concrete lived moment — a specific scene — would turn a claim into evidence.
 
 SNAPSHOTS
-When Kyle asks to save the current state, or when he asks you to develop the full draft, emit exactly one marker line before the draft tags: <snapshot stage="middle"/> or <snapshot stage="full"/>. A middle draft still has [YOUR TURN: ...] gaps; a full draft is fully developed prose (gaps closed, though flagged lines and open tensions remain in the commentary). Do not emit the marker on ordinary revision turns.`
+When Kyle asks to save the current state, or when he asks you to develop the full draft, emit exactly one marker line before the draft tags: <snapshot stage="middle"/>, <snapshot stage="full"/>, or <snapshot stage="final"/>. A middle draft still has [YOUR TURN: ...] gaps; a full draft is fully developed prose (gaps closed, though flagged lines and open tensions remain in the commentary). Do not emit any marker on ordinary revision turns.
+
+THE FINAL HANDOFF — <snapshot stage="final"/>
+When Kyle asks to finalize, hand it off, or produce the final draft, your posture changes. Stop developing: propose no new directions, introduce no new sources, open no new tensions. Do one thing — hand the essay back to him ready to retype. Emit <snapshot stage="final"/>, give the complete final draft in the tags, and in the commentary produce the RETYPE PUNCH-LIST: the running "Lines that are mine — earn them in the retype or cut them," plus any last places a concrete lived scene would turn a claim into evidence. Keep it to what actually remains; if the essay is clean, a short list is the honest list. After you emit a final snapshot, a separate outside reader — a different model that never saw this conversation — reads the draft cold and returns its own findings; those appear beside your punch-list for Kyle. You do not need to anticipate or pre-empt that read. Your job at this stage is done when the draft is whole and the punch-list is honest; the retype is Kyle's, and his alone.`
 
 const JOURNAL_TOOL: Anthropic.Tool = {
   name: 'search_journal',
@@ -192,11 +197,11 @@ export function extractDraft(text: string): string | null {
 }
 
 export function extractSnapshotIntent(text: string): SnapshotIntent | null {
-  const m = text.match(/<snapshot stage="(middle|full)"\s*\/>/)
+  const m = text.match(/<snapshot stage="(middle|full|final)"\s*\/>/)
   if (!m) return null
   const draft = extractDraft(text)
   if (!draft) return null
-  return { stage: m[1] as 'middle' | 'full', draft_text: draft }
+  return { stage: m[1] as 'middle' | 'full' | 'final', draft_text: draft }
 }
 
 export interface TurnEvents {

--- a/academy/web/src/lib/scribe/review.ts
+++ b/academy/web/src/lib/scribe/review.ts
@@ -1,0 +1,114 @@
+// The cold outside read. Fires exactly once, at the `final` handoff stage —
+// not another voice in the ongoing conversation, the thing that ENDS it. A
+// single pass over the finished draft is finite by construction, where the
+// in-thread editor's pushback never is (it can always find one more tension).
+//
+// Deliberately a DIFFERENT model family from the Opus that wrote the draft.
+// Scribe's stated enemy is "generic AI-Stoicism," and Opus's own smoothness is
+// the flavor of it most invisible to Opus — a self-review shares the aesthetic
+// it's supposed to catch. A GPT reading the draft cold, with none of the
+// conversation's history or rationalizations, has an independent nose for
+// "this reads like an AI wrote it, not a person who lived it."
+//
+// Uses the same env access as embedChunk (process.env.OPENAI_API_KEY, direct
+// fetch), so it runs wherever corpus search already runs — no new dependency,
+// no SDK. The reviewer must never break finalization: any failure degrades to
+// an empty findings set with `error` populated, and the handoff proceeds.
+
+const DEFAULT_REVIEW_MODEL = 'gpt-4o'
+
+// The three categories are not arbitrary — each is a failure mode Scribe's own
+// system prompt names (VOICE GUARD; "the weakest claim"; "the philosophy never
+// narrates over his story"), handed to an outsider who can't launder them.
+const REVIEWER_BRIEF = `You are a sharp, honest reader. You have never met the author and you did not see how this essay was written — you only have the finished draft. The author is a Stoic practitioner developing a personal essay from his own journal; his lived experience is meant to be the spine, and the philosophy is meant to enrich that story, never narrate over it.
+
+Read the draft once, as a stranger would. Then report ONLY what you are genuinely sure of, as JSON with exactly these keys:
+
+{
+  "not_kyle": [ { "line": "<the exact phrase or sentence>", "why": "<why it reads like generic AI prose rather than a specific person who lived this>" } ],
+  "unearned": [ { "line": "<the claim>", "why": "<why it is asserted as universal or settled when the essay hasn't earned it>" } ],
+  "narrated_over": [ { "line": "<the passage>", "why": "<where the philosophy talks over the author's own story instead of enriching it>" } ]
+}
+
+Rules:
+- Quote the author's actual text in each "line" so it can be found in the draft.
+- Only flag what you are sure of. Empty arrays are the correct, honest answer when a category has nothing. Do not pad.
+- You are not rewriting and not praising. No prose outside the JSON. No preamble.`
+
+export interface ReviewFinding {
+  line: string
+  why: string
+}
+
+export interface ReviewFindings {
+  model: string
+  not_kyle: ReviewFinding[]
+  unearned: ReviewFinding[]
+  narrated_over: ReviewFinding[]
+  // Set only when the pass could not complete; arrays are empty in that case.
+  error?: string
+}
+
+function empty(model: string, error: string): ReviewFindings {
+  return { model, not_kyle: [], unearned: [], narrated_over: [], error }
+}
+
+function asFindings(raw: unknown): ReviewFinding[] {
+  if (!Array.isArray(raw)) return []
+  return raw
+    .filter((f): f is Record<string, unknown> => !!f && typeof f === 'object')
+    .map(f => ({ line: String(f.line ?? '').trim(), why: String(f.why ?? '').trim() }))
+    .filter(f => f.line || f.why)
+}
+
+// One cold pass over the final draft. Never throws — a broken reviewer must not
+// block the handoff; it degrades to an empty set with `error` populated.
+export async function reviewDraft(draft: string): Promise<ReviewFindings> {
+  const model = process.env.SCRIBE_REVIEW_MODEL || DEFAULT_REVIEW_MODEL
+  const key = process.env.OPENAI_API_KEY
+  if (!key) return empty(model, 'OPENAI_API_KEY not configured — outside read skipped.')
+  if (!draft.trim()) return empty(model, 'No draft text to review.')
+
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
+      body: JSON.stringify({
+        model,
+        temperature: 0,
+        response_format: { type: 'json_object' },
+        messages: [
+          { role: 'system', content: REVIEWER_BRIEF },
+          { role: 'user', content: `Here is the finished draft:\n\n${draft}` },
+        ],
+      }),
+    })
+    if (!res.ok) {
+      const body = await res.text().catch(() => '')
+      return empty(model, `Reviewer API ${res.status}: ${body.slice(0, 200)}`)
+    }
+    const data = await res.json()
+    const content = data?.choices?.[0]?.message?.content
+    if (typeof content !== 'string') return empty(model, 'Reviewer returned no content.')
+
+    let parsed: Record<string, unknown>
+    try {
+      parsed = JSON.parse(content)
+    } catch {
+      return empty(model, 'Reviewer returned unparseable JSON.')
+    }
+    return {
+      model,
+      not_kyle: asFindings(parsed.not_kyle),
+      unearned: asFindings(parsed.unearned),
+      narrated_over: asFindings(parsed.narrated_over),
+    }
+  } catch (e) {
+    return empty(model, e instanceof Error ? e.message : 'Reviewer call failed.')
+  }
+}
+
+// True when the pass produced at least one usable finding.
+export function hasFindings(r: ReviewFindings | null | undefined): boolean {
+  return !!r && (r.not_kyle.length > 0 || r.unearned.length > 0 || r.narrated_over.length > 0)
+}

--- a/academy/web/src/scripts/scribe-chat-smoke.ts
+++ b/academy/web/src/scripts/scribe-chat-smoke.ts
@@ -12,6 +12,7 @@
 
 import { createAdminClient } from '../lib/supabase-admin'
 import { runScribeTurn, extractSnapshotIntent, extractDraft, TurnSource } from '../lib/scribe/chat'
+import { reviewDraft } from '../lib/scribe/review'
 import { withAttribution } from '../lib/scribe/attribution'
 
 const FRAGMENT =
@@ -87,13 +88,20 @@ async function main() {
     })
     const intent = extractSnapshotIntent(result.text)
     if (intent) {
+      // Mirror the /turn route: a final snapshot fires the cold outside read.
+      const review = intent.stage === 'final' ? await reviewDraft(intent.draft_text) : null
       await admin.from('scribe_entry_drafts').insert({
         entry_id: entry.id,
         stage: intent.stage,
         draft_text: intent.draft_text,
         sources_used: result.sources.length ? result.sources : null,
+        review,
       })
       console.log(`  … snapshot intent honored: stage=${intent.stage}`)
+      if (review) {
+        const n = review.not_kyle.length + review.unearned.length + review.narrated_over.length
+        console.log(`  … outside read (${review.model}): ${review.error ? `error — ${review.error}` : `${n} findings`}`)
+      }
     }
     console.log(`  sources this turn: ${result.sources.map(s => `${s.author} (${s.mode})`).join(', ') || 'none'}`)
     allTurns.push(result)
@@ -132,6 +140,29 @@ async function main() {
   check('voice guard — Scribe flags its own lines', /mine|my phrasing/i.test(t4Commentary))
   check("Kyle's language survives the full draft", !!d4 && /character|art of living/i.test(d4!))
   console.log('\n  — full-draft commentary excerpt —\n' + excerpt(t4.text.split('<draft>')[0]))
+
+  // ── 7b. Final handoff — terminal stage + cold outside read ──
+  const t5 = await turn('final handoff', 'Finalize the draft and hand it off: produce the final draft and the retype punch-list. No new directions or sources.')
+  const d5 = extractDraft(t5.text)
+  const { data: finalSnap } = await admin
+    .from('scribe_entry_drafts')
+    .select('stage, review')
+    .eq('entry_id', entry.id)
+    .eq('stage', 'final')
+    .maybeSingle()
+  check("snapshot saved as stage='final'", !!finalSnap)
+  const t5Commentary = t5.text.replace(/<draft>[\s\S]*?<\/draft>/, '')
+  check('retype punch-list present at handoff', /mine|retype|punch|earn them|cut them/i.test(t5Commentary))
+  check("Kyle's language survives to the final draft", !!d5 && /character|art of living/i.test(d5!))
+  const review = (finalSnap?.review ?? null) as { model: string; not_kyle: unknown[]; unearned: unknown[]; narrated_over: unknown[]; error?: string } | null
+  check('outside read stored on final snapshot', !!review && typeof review.model === 'string')
+  check('outside reader is a different family than the drafter (not Opus)', !!review && !/opus|claude/i.test(review.model))
+  if (review?.error) {
+    console.log(`  (outside read degraded gracefully: ${review.error})`)
+  } else if (review) {
+    const n = review.not_kyle.length + review.unearned.length + review.narrated_over.length
+    console.log(`  outside read: ${review.model} returned ${n} findings`)
+  }
 
   // ── 5. Push-back somewhere in the conversation ──
   const allCommentary = allTurns.map(t => t.text.split('<draft>')[0]).join('\n')


### PR DESCRIPTION
## What & why
Answers two open questions about Scribe chat: *would a second reviewer help?* and *when do we call the draft done?*

- **`final` handoff stage** (past middle/full). Scribe never declares a draft finished — the hand-retype is the gate — it only signals when feedback stops converging.
- **Stage-aware spine**: full-throated pushback during development, but at `final` Scribe stops developing and produces the retype punch-list. Fixes the "an editor can always find one more thing" infinite-feedback loop.
- **Cold outside read** (`lib/scribe/review.ts`): one pass by a *different* model family (OpenAI, default `gpt-4o`), blind to the conversation — Opus can't smell its own generic-AI prose. Returns `not_kyle` / `unearned` / `narrated_over`; never throws (degrades to empty+error so it can't block finalizing). Finite by construction, so it *closes* the loop rather than extending it.
- `/turn` route fires the read only on a `final` intent, stores it on the snapshot row, streams a `review` event. UI adds a "Finalize + outside read" chip + outside-reader panel. Smoke script extended with a final turn.

## Deploy notes
- **DB migration already applied** to the shared Supabase project (`scribe_entry_drafts_final_stage_and_review`: stage CHECK now allows `final`; added `review jsonb`).
- **No new Vercel env needed** — reuses `OPENAI_API_KEY`, already set on `arete-app-c8uh`.
- `tsc --noEmit` passes. Live smoke (`scribe-chat-smoke.ts`) not yet run — costs real tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)