### PR TITLE
fix(library) reading-room link + feat(ingest) --sparse labels

### DIFF
--- a/academy/web/src/app/library/page.tsx
+++ b/academy/web/src/app/library/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import Link from 'next/link';
 import { supabase } from '@/lib/supabase';
 
 // ---------------------------------------------------------------------------
@@ -480,7 +479,7 @@ export default function LibraryOfArete() {
           />
         )}
 
-        {room === 'observatory' && <Observatory go={go} onDebate={debateConcept} />}
+        {room === 'observatory' && <Observatory go={go} onDebate={debateConcept} openWork={openWork} />}
       </div>
     </div>
   );
@@ -1589,7 +1588,7 @@ function Sky3D({ concepts, edges, freshEdges, learnedEdges, activeId, onPick, br
   );
 }
 
-function Observatory({ go, onDebate }: { go: (r: Room) => void; onDebate: (concept: string) => void }) {
+function Observatory({ go, onDebate, openWork }: { go: (r: Room) => void; onDebate: (concept: string) => void; openWork: (a: string, w: string, t: string) => void }) {
   const [data, setData] = useState<ObsData | null>(null);
   const [obsState, setObsState] = useState<ObsState | null>(null);
   const [greeting, setGreeting] = useState<{ line: string; plaque: string } | null>(null);
@@ -1809,7 +1808,7 @@ function Observatory({ go, onDebate }: { go: (r: Room) => void; onDebate: (conce
   const eraDepth = useMemo(() => eraDepthMap(concepts, obsState?.chronology), [concepts, obsState]);
 
   // ---- touch a star: one passage, attributed ----
-  type Passage = { text: string; author: string | null; work: string | null; section: string | null };
+  type Passage = { text: string; author: string | null; work: string | null; title: string | null; section: string | null };
   const [passage, setPassage] = useState<{ loading: boolean; concept: string; p: Passage | null; note: string | null } | null>(null);
   const touchStar = useCallback(async (conceptName: string) => {
     setPassage({ loading: true, concept: conceptName, p: null, note: null });
@@ -2083,7 +2082,21 @@ function Observatory({ go, onDebate }: { go: (r: Room) => void; onDebate: (conce
                 <div style={{ fontFamily: MONO, fontSize: 9.5, letterSpacing: '0.12em', textTransform: 'uppercase', color: GOLD, marginBottom: 20 }}>
                   {[passage.p.author, passage.p.work, passage.p.section].filter(Boolean).join(' · ')}
                 </div>
-                <Link href="/" className="lib-discuss" style={{ display: 'block', textAlign: 'center', textDecoration: 'none', background: 'rgba(201,168,76,0.12)', border: '1px solid rgba(201,168,76,0.35)', borderRadius: 11, padding: 12, fontFamily: MONO, fontSize: 9.5, letterSpacing: '0.14em', textTransform: 'uppercase', color: GOLD }}>Read the whole tradition at the Academy →</Link>
+                {/* Stay in the Library: open the work this passage came from
+                    in the reading room. Only when the chunk lost its
+                    attribution do we fall back to the shelves. */}
+                <button
+                  onClick={() => {
+                    const p = passage.p!;
+                    setPassage(null);
+                    if (p.author && p.work) openWork(p.author, p.work, p.title || p.work);
+                    else go('reading');
+                  }}
+                  className="lib-discuss"
+                  style={{ display: 'block', width: '100%', textAlign: 'center', cursor: 'pointer', background: 'rgba(201,168,76,0.12)', border: '1px solid rgba(201,168,76,0.35)', borderRadius: 11, padding: 12, fontFamily: MONO, fontSize: 9.5, letterSpacing: '0.14em', textTransform: 'uppercase', color: GOLD }}
+                >
+                  {passage.p.work ? `Read ${passage.p.title || passage.p.work} in full →` : 'Read the sources in full →'}
+                </button>
               </>
             )}
             {!passage.loading && !passage.p && (

--- a/academy/web/src/scripts/ingest-labeled-work.ts
+++ b/academy/web/src/scripts/ingest-labeled-work.ts
@@ -30,6 +30,15 @@ function flag(name: string): boolean {
 
 interface Boundary { offset: number; label: string }
 
+// Range-aware join: labels may themselves be ranges ("2.54–2.59") — a chunk
+// spanning several takes the low end of the first and the high end of the last.
+function joinLabels(a: string, b: string): string {
+  const lo = a.split('–')[0]
+  const parts = b.split('–')
+  const hi = parts[parts.length - 1]
+  return lo === hi ? lo : `${lo}–${hi}`
+}
+
 function labelFor(boundaries: Boundary[], start: number, end: number): string {
   let first = boundaries[0]
   for (const b of boundaries) {
@@ -40,7 +49,23 @@ function labelFor(boundaries: Boundary[], start: number, end: number): string {
   const last = spanned.length ? spanned[spanned.length - 1] : first
   if (first.label === last.label) return first.label
   if (first.label === 'front matter') return spanned.length === 1 ? last.label : `front matter–${last.label}`
-  return `${first.label}–${last.label}`
+  return joinLabels(first.label, last.label)
+}
+
+// --sparse: the source anchors only some sections (e.g. ToposText ND anchors
+// 170 of ~370). Expand each anchor's label to the range it actually covers —
+// "2.54" followed by "2.60" becomes "2.54–2.59" — so citations of the
+// unanchored sections in between verify instead of false-mismatching.
+function expandSparse(boundaries: Boundary[]): void {
+  for (let i = 1; i < boundaries.length - 1; i++) {
+    const cur = boundaries[i].label
+    const next = boundaries[i + 1].label
+    const c = cur.match(/^(.*?)(\d+)$/)
+    const n = next.match(/^(.*?)(\d+)$/)
+    if (!c || !n || c[1] !== n[1]) continue // sentinel or book boundary
+    const gapEnd = parseInt(n[2], 10) - 1
+    if (gapEnd > parseInt(c[2], 10)) boundaries[i].label = `${cur}–${c[1]}${gapEnd}`
+  }
 }
 
 async function main() {
@@ -68,6 +93,7 @@ async function main() {
     if (m) boundaries.push({ offset, label: `${prefix}${m[1]}` })
     offset += line.split(/\s+/).filter(Boolean).length
   }
+  if (flag('sparse')) expandSparse(boundaries)
   const words = raw.split(/\s+/).filter(Boolean)
   console.log(`${author}, ${work}: ${words.length.toLocaleString()} words · ${boundaries.length - 1} passages (…${boundaries[boundaries.length - 1].label})`)
 


### PR DESCRIPTION
Two independent academy fixes (video-intro work held back pending an asset decision):

- **Library / Observatory**: touching a star now opens the passage's source work in the reading room instead of linking to the home page; falls back to the shelves when attribution is missing.
- **ingest-labeled-work.ts**: `--sparse` expands each anchor's label to the range it covers (for partially-anchored sources like ToposText ND) so in-between citations verify; range-aware label joins.

Both compile (`tsc --noEmit` clean). No new env or migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)