### PR TITLE
fix(scribe): outside-reader panel no longer crushes the draft pane

### DIFF
--- a/academy/web/src/app/admin/scribe/chat/chat.module.css
+++ b/academy/web/src/app/admin/scribe/chat/chat.module.css
@@ -57,6 +57,18 @@
 
 .paneBody { overflow-y: auto; padding: 12px 14px; flex: 1; }
 
+/* Outside-reader findings inside the draft pane: capped with its own scroll so
+   it never starves the draft above it. */
+.reviewPanel {
+  flex-shrink: 0;
+  max-height: 38%;
+  overflow-y: auto;
+  border-top: 0.5px solid #eee;
+  padding: 12px 14px;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
 /* ── Sidebar ── */
 .entryItem {
   display: block;

--- a/academy/web/src/app/admin/scribe/chat/page.tsx
+++ b/academy/web/src/app/admin/scribe/chat/page.tsx
@@ -455,7 +455,7 @@ export default function ScribeChatPage() {
                 : <p className={styles.draftEmpty}>The working draft appears here as Scribe writes.</p>}
             </div>
             {reviewShown && (
-              <div style={{ borderTop: '1px solid var(--border, #2a2a2a)', padding: '12px 16px', fontSize: 13 }}>
+              <div className={styles.reviewPanel}>
                 <div style={{ fontWeight: 600, marginBottom: 6 }}>
                   Outside reader{reviewShown.model ? ` · ${reviewShown.model}` : ''} — read the draft cold
                 </div>


### PR DESCRIPTION
The final-stage review panel was an unconstrained div inside the fixed-height draft pane, so a full findings list squeezed the draft (`flex:1`) down to one line. Now it's a capped, scrollable region (`.reviewPanel`: `flex-shrink:0; max-height:38%; overflow-y:auto`) so the draft keeps its space. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)