### PR TITLE
feat(scribe): voice exemplars, prose-physics rules, AI-tell voice meter

### DIFF
--- a/academy/web/src/app/admin/scribe/chat/page.tsx
+++ b/academy/web/src/app/admin/scribe/chat/page.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import admin from '../../admin.module.css'
 import styles from './chat.module.css'
 import { withAttribution } from '@/lib/scribe/attribution'
+import { computeVoiceMetrics } from '@/lib/scribe/voice-metrics'
 
 type Entry = { id: string; title: string | null; raw_text: string; created_at: string; updated_at: string }
 type Source = {
@@ -28,12 +29,13 @@ type Review = {
   not_kyle: ReviewFinding[]
   unearned: ReviewFinding[]
   narrated_over: ReviewFinding[]
+  tells?: ReviewFinding[]
   error?: string
 }
 type Draft = { id: string; stage: 'middle' | 'full' | 'final'; draft_text: string; sources_used: Source[] | null; review: Review | null; created_at: string }
 
 function reviewHasFindings(r: Review | null | undefined): boolean {
-  return !!r && (r.not_kyle.length > 0 || r.unearned.length > 0 || r.narrated_over.length > 0)
+  return !!r && (r.not_kyle.length > 0 || r.unearned.length > 0 || r.narrated_over.length > 0 || (r.tells?.length ?? 0) > 0)
 }
 
 function extractDraft(text: string): string | null {
@@ -258,6 +260,8 @@ export default function ScribeChatPage() {
   // A viewed final snapshot shows its own stored read; otherwise the live one
   // from the turn just finished.
   const reviewShown = viewedSnapshot?.review ?? (viewedDraftId ? null : liveReview)
+  // Deterministic voice meter — recomputed from whatever draft is shown.
+  const voiceMetrics = draftShown ? computeVoiceMetrics(draftShown) : null
 
   // Source panel: live during a turn, else the latest scribe turn's sources.
   const latestSources = (() => {
@@ -454,6 +458,20 @@ export default function ScribeChatPage() {
                 ? <div className={styles.draftText}>{draftShown}</div>
                 : <p className={styles.draftEmpty}>The working draft appears here as Scribe writes.</p>}
             </div>
+            {voiceMetrics && (
+              <div style={{ flexShrink: 0, borderTop: '0.5px solid #eee', padding: '7px 14px', fontSize: 11.5, color: '#555', display: 'flex', flexWrap: 'wrap', gap: '3px 14px', alignItems: 'center' }}>
+                <span style={{ textTransform: 'uppercase', letterSpacing: '0.06em', color: '#aaa', fontSize: 10 }}>Voice meter</span>
+                <span title="Std-dev of sentence length in words. Higher = more human rhythm variation; flat prose is an AI tell.">
+                  rhythm <strong style={{ color: voiceMetrics.burstinessLabel === 'good' ? '#2e7d32' : voiceMetrics.burstinessLabel === 'ok' ? '#b8860b' : '#c0392b' }}>{voiceMetrics.burstiness}</strong> ({voiceMetrics.burstinessLabel})
+                </span>
+                <span title="Average words per sentence.">avg {voiceMetrics.meanSentenceLen}w</span>
+                <span title="-ly adverbs per 100 words. Lower is usually tighter.">adverbs {voiceMetrics.adverbRate}</span>
+                <span title="to-be verbs (is/are/was…) per 100 words. High = flatter prose.">to-be {voiceMetrics.toBeRate}</span>
+                <span title={voiceMetrics.tellHits.map(h => `${h.phrase} ×${h.count}`).join(', ') || 'no cliché tells found'}>
+                  AI tells <strong style={{ color: voiceMetrics.tellTotal === 0 ? '#2e7d32' : '#c0392b' }}>{voiceMetrics.tellTotal}</strong>
+                </span>
+              </div>
+            )}
             {reviewShown && (
               <div className={styles.reviewPanel}>
                 <div style={{ fontWeight: 600, marginBottom: 6 }}>
@@ -468,6 +486,7 @@ export default function ScribeChatPage() {
                     ['Reads like AI, not you', reviewShown.not_kyle],
                     ['Claims not yet earned', reviewShown.unearned],
                     ['Philosophy narrating over your story', reviewShown.narrated_over],
+                    ['Mechanical AI tells', reviewShown.tells ?? []],
                   ] as [string, ReviewFinding[]][]).map(([label, items]) => items.length > 0 && (
                     <div key={label} style={{ marginBottom: 8 }}>
                       <div style={{ fontWeight: 600, opacity: 0.8, marginBottom: 2 }}>{label}</div>

--- a/academy/web/src/app/api/admin/scribe/entries/[id]/turn/route.ts
+++ b/academy/web/src/app/api/admin/scribe/entries/[id]/turn/route.ts
@@ -61,13 +61,26 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
       const emit = (t: string, v: unknown) =>
         controller.enqueue(encoder.encode(JSON.stringify({ t, v }) + '\n'))
       try {
+        // Kyle's voice = the active style profile (newest-updated), the same
+        // store the pipeline draft stage reads. Null if he hasn't added one.
+        const { data: style } = await admin
+          .from('scribe_style_profiles')
+          .select('exemplar_refs, guidance')
+          .order('updated_at', { ascending: false })
+          .limit(1)
+          .maybeSingle()
+        const voice = style
+          ? { exemplars: style.exemplar_refs ?? [], guidance: style.guidance ?? null }
+          : null
+
         const { text, sources } = await runScribeTurn(
           thread as { role: 'user' | 'scribe'; content: string }[],
           {
             onText: v => emit('text', v),
             onSearching: v => emit('searching', v),
             onSources: (v: TurnSource[]) => emit('sources', v),
-          }
+          },
+          voice
         )
 
         const { data: saved, error: saveError } = await admin

--- a/academy/web/src/lib/scribe/chat.ts
+++ b/academy/web/src/lib/scribe/chat.ts
@@ -40,6 +40,14 @@ export interface SnapshotIntent {
   draft_text: string
 }
 
+// Kyle's voice, sourced from the active scribe_style_profiles row (the same
+// store the pipeline draft stage uses). Injected into the system prompt so
+// Scribe develops in his actual cadence and diction, not generic-essay prose.
+export interface VoiceProfile {
+  exemplars: { title: string; text: string }[]
+  guidance: string | null
+}
+
 type RagHit = {
   id: string
   chunk_text: string
@@ -89,6 +97,16 @@ But an editor with a spine can always find one more thing — and a draft that n
 
 VOICE GUARD — even at the finish
 Whenever you produce or revise a full draft, flag the lines that are YOUR phrasing rather than Kyle's (a short list in the commentary: "Lines that are mine — earn them in the retype or cut them"), and point to where a concrete lived moment — a specific scene — would turn a claim into evidence.
+
+PROSE PHYSICS — how the sentences must move
+Generic machine prose has two tells, and they are the same two things that make writing dull: every sentence runs the same length, and every word is the most predictable one. Write against both, on every draft:
+- Vary the rhythm hard. Follow a long, winding sentence with a three-word one. A fragment is allowed. If your paragraphs all have the same cadence, you have failed — read them aloud in your head and break the pattern.
+- Choose the specific concrete word over the general one every time: the gutter he never fixed, not "a reminder of loss." Name the thing. Prefer strong verbs to adverbs; cut "very," "really," "quite."
+- Kill the scaffolding: no "firstly / secondly / in conclusion," no "it's important to note," no "moreover / furthermore." Kill the hedge stack ("while X, it's also true that Y"). Say the thing.
+- Break the rule-of-three reflex. Machine prose reaches for "clarity, purpose, and meaning." Do not stack three parallel items unless the third genuinely earns its place; two is often stronger, and an unexpected single is stronger still.
+- No thesaurus diction: no "delve," "tapestry," "testament to," "navigate the complexities," "underscore," "landscape," "realm." Plain, exact words.
+- Land, don't summarize. The last line is a turn — it arrives somewhere the reader didn't see coming but now finds inevitable. Never restate what the essay already said.
+These rules never override THE SPINE or the VOICE GUIDANCE below; when they conflict, Kyle's actual voice wins.
 
 SNAPSHOTS
 When Kyle asks to save the current state, or when he asks you to develop the full draft, emit exactly one marker line before the draft tags: <snapshot stage="middle"/>, <snapshot stage="full"/>, or <snapshot stage="final"/>. A middle draft still has [YOUR TURN: ...] gaps; a full draft is fully developed prose (gaps closed, though flagged lines and open tensions remain in the commentary). Do not emit any marker on ordinary revision turns.
@@ -213,15 +231,33 @@ export interface TurnEvents {
 // Run one Scribe turn: full thread as history, agentic search loop, streamed
 // text. Returns the complete assistant text and every source retrieved on
 // this turn (for scribe_messages.sources_used — the audit trail).
+// Append Kyle's voice reference to the base system prompt. Same framing the
+// pipeline draft stage uses, so the two paths sound like the same author.
+function buildSystem(voice: VoiceProfile | null): string {
+  if (!voice) return SYSTEM_PROMPT
+  let s = SYSTEM_PROMPT
+  const exemplars = (voice.exemplars ?? [])
+    .filter(e => e?.text?.trim())
+    .map((e, i) => `--- exemplar ${i + 1}: ${e.title} ---\n${e.text}`)
+    .join('\n\n')
+  if (exemplars) {
+    s += `\n\nHOW KYLE WRITES — these are his own paragraphs. Match this cadence, sentence-length variation, diction, and how he opens and closes; this is the voice the finished essay must sound like. Learn the voice, do NOT reuse their content:\n\n${exemplars}`
+  }
+  if (voice.guidance?.trim()) s += `\n\nVOICE GUIDANCE: ${voice.guidance.trim()}`
+  return s
+}
+
 export async function runScribeTurn(
   history: { role: 'user' | 'scribe'; content: string }[],
-  events: TurnEvents
+  events: TurnEvents,
+  voice: VoiceProfile | null = null
 ): Promise<{ text: string; sources: TurnSource[] }> {
   const messages: Anthropic.MessageParam[] = history.map(m => ({
     role: m.role === 'scribe' ? 'assistant' : 'user',
     content: m.content,
   }))
 
+  const systemText = buildSystem(voice)
   const turnSources: TurnSource[] = []
   const seenChunks = new Set<string>()
   let fullText = ''
@@ -231,7 +267,7 @@ export async function runScribeTurn(
     const stream = getClient().messages.stream({
       model: CHAT_MODEL,
       max_tokens: MAX_TOKENS,
-      system: SYSTEM_PROMPT,
+      system: systemText,
       messages,
       // On the final permitted round withhold the tools so the model must
       // finish the turn with what it has retrieved.

--- a/academy/web/src/lib/scribe/review.ts
+++ b/academy/web/src/lib/scribe/review.ts
@@ -27,7 +27,8 @@ Read the draft once, as a stranger would. Then report ONLY what you are genuinel
 {
   "not_kyle": [ { "line": "<the exact phrase or sentence>", "why": "<why it reads like generic AI prose rather than a specific person who lived this>" } ],
   "unearned": [ { "line": "<the claim>", "why": "<why it is asserted as universal or settled when the essay hasn't earned it>" } ],
-  "narrated_over": [ { "line": "<the passage>", "why": "<where the philosophy talks over the author's own story instead of enriching it>" } ]
+  "narrated_over": [ { "line": "<the passage>", "why": "<where the philosophy talks over the author's own story instead of enriching it>" } ],
+  "tells": [ { "line": "<the exact phrase or sentence>", "why": "<the mechanical AI-writing tell: uniform sentence rhythm, rule-of-three / parallelism overuse, signposting (firstly/in conclusion), hedging, thesaurus diction (delve, tapestry, underscore), or cliché phrasing>" } ]
 }
 
 Rules:
@@ -45,12 +46,13 @@ export interface ReviewFindings {
   not_kyle: ReviewFinding[]
   unearned: ReviewFinding[]
   narrated_over: ReviewFinding[]
+  tells: ReviewFinding[]
   // Set only when the pass could not complete; arrays are empty in that case.
   error?: string
 }
 
 function empty(model: string, error: string): ReviewFindings {
-  return { model, not_kyle: [], unearned: [], narrated_over: [], error }
+  return { model, not_kyle: [], unearned: [], narrated_over: [], tells: [], error }
 }
 
 function asFindings(raw: unknown): ReviewFinding[] {
@@ -102,6 +104,7 @@ export async function reviewDraft(draft: string): Promise<ReviewFindings> {
       not_kyle: asFindings(parsed.not_kyle),
       unearned: asFindings(parsed.unearned),
       narrated_over: asFindings(parsed.narrated_over),
+      tells: asFindings(parsed.tells),
     }
   } catch (e) {
     return empty(model, e instanceof Error ? e.message : 'Reviewer call failed.')
@@ -110,5 +113,5 @@ export async function reviewDraft(draft: string): Promise<ReviewFindings> {
 
 // True when the pass produced at least one usable finding.
 export function hasFindings(r: ReviewFindings | null | undefined): boolean {
-  return !!r && (r.not_kyle.length > 0 || r.unearned.length > 0 || r.narrated_over.length > 0)
+  return !!r && (r.not_kyle.length > 0 || r.unearned.length > 0 || r.narrated_over.length > 0 || r.tells.length > 0)
 }

--- a/academy/web/src/lib/scribe/voice-metrics.ts
+++ b/academy/web/src/lib/scribe/voice-metrics.ts
@@ -1,0 +1,116 @@
+// Deterministic "voice meter" — cheap, no LLM. Surfaces the two mechanical
+// signals AI screeners actually key on (uniform sentence rhythm = low
+// burstiness; predictable, padded diction) plus a cliché/tell wordlist, so
+// Kyle can see how machine-shaped a draft reads before he retypes it. These
+// are heuristics, not a verdict; the retype is what fixes them.
+
+export interface TellHit {
+  phrase: string
+  count: number
+}
+
+export interface VoiceMetrics {
+  words: number
+  sentences: number
+  meanSentenceLen: number
+  // Std deviation of sentence length in words. Human essays vary a lot (often
+  // >8); uniform machine prose sits low. Higher is more human.
+  burstiness: number
+  burstinessLabel: 'flat' | 'ok' | 'good'
+  // Per-100-words rates.
+  adverbRate: number // words ending in -ly
+  toBeRate: number // is/are/was/were/be/been/being/am
+  tellHits: TellHit[]
+  tellTotal: number
+}
+
+// High-signal AI/blog tells. Matched case-insensitively as whole phrases.
+const TELLS: string[] = [
+  'at the end of the day',
+  'in a world where',
+  "in today's world",
+  'it is important to note',
+  "it's important to note",
+  'it is worth noting',
+  'needless to say',
+  'first and foremost',
+  'when it comes to',
+  'moreover',
+  'furthermore',
+  'in conclusion',
+  'ultimately,',
+  'in essence',
+  'delve',
+  'tapestry',
+  'testament to',
+  'navigate the complexities',
+  'navigating the complexities',
+  'underscore',
+  'the ever-evolving',
+  'ever-changing',
+  'landscape of',
+  'realm of',
+  'pivotal',
+  'crucial role',
+  'seamless',
+  'robust',
+  'holistic',
+  'leverage',
+  'myriad',
+  'plethora',
+  'a beacon of',
+  'stands as a',
+  'plays a vital role',
+  'rich tapestry',
+]
+
+function stdev(nums: number[]): number {
+  if (nums.length < 2) return 0
+  const mean = nums.reduce((a, b) => a + b, 0) / nums.length
+  const variance = nums.reduce((a, b) => a + (b - mean) ** 2, 0) / nums.length
+  return Math.sqrt(variance)
+}
+
+export function computeVoiceMetrics(text: string): VoiceMetrics {
+  const clean = (text || '').trim()
+  const words = clean ? clean.split(/\s+/).filter(Boolean) : []
+  const wordCount = words.length
+
+  // Sentence split on terminal punctuation; keep only non-empty runs.
+  const sentences = clean
+    .split(/(?<=[.!?])\s+/)
+    .map(s => s.trim())
+    .filter(Boolean)
+  const sentenceLens = sentences.map(s => s.split(/\s+/).filter(Boolean).length).filter(n => n > 0)
+  const sentenceCount = sentenceLens.length
+  const meanSentenceLen = sentenceCount ? wordCount / sentenceCount : 0
+  const burstiness = stdev(sentenceLens)
+  const burstinessLabel: VoiceMetrics['burstinessLabel'] =
+    burstiness >= 8 ? 'good' : burstiness >= 5 ? 'ok' : 'flat'
+
+  const per100 = (n: number) => (wordCount ? Math.round((n / wordCount) * 1000) / 10 : 0)
+  const adverbs = words.filter(w => /[a-z]{3,}ly[.,;:!?)"']*$/i.test(w)).length
+  const lower = ` ${clean.toLowerCase()} `
+  const toBe = (lower.match(/\b(is|are|was|were|be|been|being|am)\b/g) || []).length
+
+  const tellHits: TellHit[] = []
+  for (const t of TELLS) {
+    const re = new RegExp(t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi')
+    const count = (lower.match(re) || []).length
+    if (count > 0) tellHits.push({ phrase: t, count })
+  }
+  tellHits.sort((a, b) => b.count - a.count)
+  const tellTotal = tellHits.reduce((a, h) => a + h.count, 0)
+
+  return {
+    words: wordCount,
+    sentences: sentenceCount,
+    meanSentenceLen: Math.round(meanSentenceLen * 10) / 10,
+    burstiness: Math.round(burstiness * 10) / 10,
+    burstinessLabel,
+    adverbRate: per100(adverbs),
+    toBeRate: per100(toBe),
+    tellHits,
+    tellTotal,
+  }
+}


### PR DESCRIPTION
Makes chat-developed essays read as genuinely Kyle's — the same thing as reading human to an AI screener (screeners key on uniform rhythm + predictable diction, which are also just the marks of dull prose). No detector gimmicks.

- **Voice exemplars (#1)**: chat injects the active `scribe_style_profiles` row (exemplars + guidance) into the system prompt — the same voice store the pipeline uses. Populate via the Voice card on /admin/scribe.
- **Prose physics (#2)**: system prompt mandates rhythm variation + concrete diction; bans signposting / hedging / rule-of-three / thesaurus words; land on a turn. Yields to spine + voice.
- **Voice meter + AI-tell lens (#3)**: `voice-metrics.ts` (burstiness, adverb/to-be rates, cliché wordlist) shown live in the draft pane, no LLM cost; gpt-4o cold read gains a `tells` category.

`tsc` clean. Metrics verified: AI-ish text → rhythm 3.7 / 10 tells; human prose → rhythm 11.5 / 0 tells. No migration (review jsonb already flexible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)