### PR TITLE
feat(interlocutor): marked-up feedback studio with draft iteration

### DIFF
--- a/academy/supabase/migrations/005_interlocutor_studio.sql
+++ b/academy/supabase/migrations/005_interlocutor_studio.sql
@@ -1,0 +1,130 @@
+-- The Interlocutor Studio — inline marked-up feedback + draft iteration.
+--
+-- Builds on 004_interlocutor.sql. Where 004 gave the agent a one-shot prose
+-- critique and a derived writing_profile, this adds the surfaces that let a
+-- student iterate: a persisted piece, an immutable snapshot per submission, and
+-- annotations anchored to that snapshot.
+--
+-- Three tables:
+--   writing_pieces   — one row per piece the student is working on. `stage` is
+--                      reserved for the later guided-flow phase; it defaults to
+--                      'draft' and nothing reads it yet.
+--   piece_drafts     — one immutable snapshot per submission. Annotations anchor
+--                      to a specific version by character offset, so a later edit
+--                      never drifts an existing markup: the student revises into a
+--                      NEW version instead.
+--   draft_annotations— one marked-up span per row: offsets into the draft's
+--                      content, the rubric dimension, a severity, the teaching
+--                      comment, and an optional concrete rewrite `suggestion`.
+--
+-- critique_history (from 004) is still written by the annotate route, one row per
+-- pass, so the nightly writing_profile derivation keeps working untouched.
+--
+-- RLS mirrors 004: the student owns their rows; admins may read. Offsets are
+-- computed server-side from the model's verbatim quotes, never trusted from the
+-- model, so a client never needs to write annotations directly (insert stays
+-- server-side under the user's session); the student may still update status
+-- (accept / dismiss) and delete their own work.
+
+create table if not exists public.writing_pieces (
+  id          uuid primary key default gen_random_uuid(),
+  user_id     uuid not null references auth.users(id) on delete cascade,
+  title       text,
+  -- Reserved for the guided stage flow (thesis|outline|draft|revise|polish).
+  -- Free text with a default rather than an enum so the flow can grow without a
+  -- migration; nothing reads it yet.
+  stage       text not null default 'draft',
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now()
+);
+
+create table if not exists public.piece_drafts (
+  id          uuid primary key default gen_random_uuid(),
+  piece_id    uuid not null references public.writing_pieces(id) on delete cascade,
+  user_id     uuid not null references auth.users(id) on delete cascade,
+  -- 1-based, contiguous per piece. Unique so a double-submit cannot fork history.
+  version     int not null,
+  -- The immutable snapshot the annotations anchor to. Never updated.
+  content     text not null,
+  word_count  int not null default 0,
+  created_at  timestamptz not null default now(),
+  unique (piece_id, version)
+);
+
+create table if not exists public.draft_annotations (
+  id            uuid primary key default gen_random_uuid(),
+  draft_id      uuid not null references public.piece_drafts(id) on delete cascade,
+  user_id       uuid not null references auth.users(id) on delete cascade,
+  -- Character offsets into piece_drafts.content [start, end). Located server-side
+  -- from `quote`; an annotation the server could not place is stored with both
+  -- offsets null and surfaces as a general note rather than an inline highlight.
+  start_offset  int,
+  end_offset    int,
+  quote         text not null,
+  -- One of the rubric dimensions (thesis, validity, soundness, charity, economy,
+  -- fidelity). Text, not an enum, to match critique_history.dimensions_flagged.
+  dimension     text not null,
+  severity      text not null default 'note'
+                check (severity in ('critical','major','minor','note','strength')),
+  -- The diagnosis: names the flaw and why it matters. Always present, even when a
+  -- rewrite is offered, so a suggestion still teaches.
+  comment       text not null,
+  -- The optional concrete rewrite. Null for a pure diagnosis or a strength.
+  suggestion    text,
+  status        text not null default 'open'
+                check (status in ('open','accepted','dismissed')),
+  created_at    timestamptz not null default now()
+);
+
+alter table public.writing_pieces    enable row level security;
+alter table public.piece_drafts       enable row level security;
+alter table public.draft_annotations  enable row level security;
+
+-- writing_pieces: the student owns the piece end to end.
+create policy "writing_pieces_select_own" on public.writing_pieces
+  for select using (auth.uid() = user_id);
+create policy "writing_pieces_insert_own" on public.writing_pieces
+  for insert with check (auth.uid() = user_id);
+create policy "writing_pieces_update_own" on public.writing_pieces
+  for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+create policy "writing_pieces_delete_own" on public.writing_pieces
+  for delete using (auth.uid() = user_id);
+create policy "writing_pieces_admin_select" on public.writing_pieces
+  for select using (
+    exists (select 1 from public.profiles p where p.id = auth.uid() and p.is_admin)
+  );
+
+-- piece_drafts: read and delete own. No update policy: a version is an immutable
+-- record of what was submitted, like critique_history.
+create policy "piece_drafts_select_own" on public.piece_drafts
+  for select using (auth.uid() = user_id);
+create policy "piece_drafts_insert_own" on public.piece_drafts
+  for insert with check (auth.uid() = user_id);
+create policy "piece_drafts_delete_own" on public.piece_drafts
+  for delete using (auth.uid() = user_id);
+create policy "piece_drafts_admin_select" on public.piece_drafts
+  for select using (
+    exists (select 1 from public.profiles p where p.id = auth.uid() and p.is_admin)
+  );
+
+-- draft_annotations: read/insert/delete own, plus update own for the accept /
+-- dismiss action the student drives from the review view.
+create policy "draft_annotations_select_own" on public.draft_annotations
+  for select using (auth.uid() = user_id);
+create policy "draft_annotations_insert_own" on public.draft_annotations
+  for insert with check (auth.uid() = user_id);
+create policy "draft_annotations_update_own" on public.draft_annotations
+  for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+create policy "draft_annotations_delete_own" on public.draft_annotations
+  for delete using (auth.uid() = user_id);
+create policy "draft_annotations_admin_select" on public.draft_annotations
+  for select using (
+    exists (select 1 from public.profiles p where p.id = auth.uid() and p.is_admin)
+  );
+
+create index if not exists writing_pieces_user_updated_idx
+  on public.writing_pieces (user_id, updated_at desc);
+create index if not exists piece_drafts_piece_version_idx
+  on public.piece_drafts (piece_id, version desc);
+create index if not exists draft_annotations_draft_idx
+  on public.draft_annotations (draft_id);

--- a/academy/web/src/app/api/interlocutor/annotate/route.ts
+++ b/academy/web/src/app/api/interlocutor/annotate/route.ts
@@ -1,0 +1,313 @@
+import { NextRequest, NextResponse } from 'next/server'
+import Anthropic from '@anthropic-ai/sdk'
+import { createClient } from '@/lib/supabase-server'
+import {
+  INTERLOCUTOR_SYSTEM,
+  ANNOTATION_APPENDIX,
+  RUBRIC_DIMENSIONS,
+  SEVERITY_LEVELS,
+  buildProfileBlock,
+  type WritingProfileRow,
+  type AnnotationOut,
+} from '@/lib/interlocutor'
+import { locate } from '@/lib/annotations'
+
+// POST /api/interlocutor/annotate — the marked-up pass. The Interlocutor reads a
+// draft and returns a summary plus annotations anchored to verbatim quotes; this
+// route snapshots the draft as an immutable version, locates each quote's offsets
+// server-side (the model is never trusted to count characters), and persists the
+// annotations so the student can iterate version to version.
+//
+// One critique_history row is still written per pass so the nightly
+// writing_profile derivation (server/interlocutor-profile.js) keeps working
+// unchanged.
+//
+// Body: { pieceId?, title?, draftContent, stage? }
+// Returns: { pieceId, draftId, version, summary, annotations, generalNotes }
+
+const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
+
+export const maxDuration = 300
+
+const MIN_DRAFT = 40
+const MAX_DRAFT = 60000
+const MAX_ANNOTATIONS = 60
+
+const ANNOTATION_SCHEMA = {
+  type: 'object',
+  properties: {
+    summary: { type: 'string' },
+    annotations: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          quote: { type: 'string' },
+          dimension: { type: 'string', enum: [...RUBRIC_DIMENSIONS] },
+          severity: { type: 'string', enum: [...SEVERITY_LEVELS] },
+          comment: { type: 'string' },
+          suggestion: { type: ['string', 'null'] },
+        },
+        required: ['quote', 'dimension', 'severity', 'comment', 'suggestion'],
+        additionalProperties: false,
+      },
+    },
+    dimensions_flagged: {
+      type: 'array',
+      items: { type: 'string', enum: [...RUBRIC_DIMENSIONS] },
+    },
+  },
+  required: ['summary', 'annotations', 'dimensions_flagged'],
+  additionalProperties: false,
+} as const
+
+// The stored annotation, offsets resolved. start/end are null when the quote
+// could not be placed in the draft: it becomes a general note rather than an
+// inline highlight, so nothing the model said is silently dropped.
+interface StoredAnnotation {
+  id: string
+  start_offset: number | null
+  end_offset: number | null
+  quote: string
+  dimension: string
+  severity: string
+  comment: string
+  suggestion: string | null
+  status: string
+}
+
+export async function POST(req: NextRequest) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: {
+    pieceId?: string
+    title?: string
+    draftContent?: string
+    stage?: string
+  }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const draftContent = typeof body.draftContent === 'string' ? body.draftContent : ''
+  const trimmed = draftContent.trim()
+  if (trimmed.length < MIN_DRAFT) {
+    return NextResponse.json(
+      { error: 'Write at least a few sentences. There is nothing to mark up in less.' },
+      { status: 400 }
+    )
+  }
+  if (draftContent.length > MAX_DRAFT) {
+    return NextResponse.json(
+      { error: 'That draft is too long for a single pass. Submit it in parts.' },
+      { status: 400 }
+    )
+  }
+
+  const title =
+    typeof body.title === 'string' && body.title.trim() ? body.title.trim().slice(0, 200) : null
+
+  // ── Resolve the piece: reuse an owned one, or start a new one ────────────────
+  let pieceId: string
+  if (typeof body.pieceId === 'string' && body.pieceId) {
+    const { data: piece, error } = await supabase
+      .from('writing_pieces')
+      .select('id')
+      .eq('id', body.pieceId)
+      .eq('user_id', user.id)
+      .maybeSingle()
+    if (error || !piece) {
+      return NextResponse.json({ error: 'Piece not found' }, { status: 404 })
+    }
+    pieceId = (piece as { id: string }).id
+    // Keep the title and the updated_at current.
+    await supabase
+      .from('writing_pieces')
+      .update({ title, updated_at: new Date().toISOString() })
+      .eq('id', pieceId)
+      .eq('user_id', user.id)
+  } else {
+    const { data: created, error } = await supabase
+      .from('writing_pieces')
+      .insert({ user_id: user.id, title, stage: body.stage || 'draft' })
+      .select('id')
+      .single()
+    if (error || !created) {
+      console.error('[interlocutor/annotate] piece insert failed:', error?.message)
+      return NextResponse.json({ error: 'Could not start the piece' }, { status: 500 })
+    }
+    pieceId = (created as { id: string }).id
+  }
+
+  // ── Profile injection (a missing profile is not an error) ────────────────────
+  let profile: WritingProfileRow | null = null
+  try {
+    const { data } = await supabase
+      .from('writing_profile')
+      .select('recurring_failures, cleared_standards, strengths, current_edge, pieces_reviewed, updated_at')
+      .eq('user_id', user.id)
+      .maybeSingle()
+    profile = (data as WritingProfileRow | null) ?? null
+  } catch (e) {
+    console.warn('[interlocutor/annotate] profile read failed:', e)
+  }
+
+  const system = [INTERLOCUTOR_SYSTEM + ANNOTATION_APPENDIX, buildProfileBlock(profile)].join('\n\n')
+
+  const userContent = [
+    title ? `PIECE: ${title}` : null,
+    'THE DRAFT. Mark this up:',
+    `\n<draft>\n${draftContent}\n</draft>`,
+  ]
+    .filter(Boolean)
+    .join('\n\n')
+
+  // ── The model ────────────────────────────────────────────────────────────────
+  let parsed: { summary: string; annotations: AnnotationOut[]; dimensions_flagged: string[] }
+  try {
+    const response = await client.messages.create({
+      model: 'claude-opus-4-8',
+      max_tokens: 16000,
+      thinking: { type: 'adaptive' },
+      system,
+      messages: [{ role: 'user', content: userContent }],
+      output_config: { format: { type: 'json_schema', schema: ANNOTATION_SCHEMA } },
+    })
+
+    if (response.stop_reason === 'refusal') {
+      return NextResponse.json({ error: 'The Interlocutor declined this draft.' }, { status: 502 })
+    }
+    const text = response.content.find(b => b.type === 'text')
+    if (!text || text.type !== 'text') {
+      return NextResponse.json({ error: 'No markup produced' }, { status: 502 })
+    }
+    parsed = JSON.parse(text.text)
+  } catch (e) {
+    console.error('[interlocutor/annotate]', e)
+    return NextResponse.json({ error: 'The Interlocutor is unavailable' }, { status: 502 })
+  }
+
+  const summary = (parsed.summary ?? '').trim()
+  const rawAnnotations = (Array.isArray(parsed.annotations) ? parsed.annotations : []).slice(
+    0,
+    MAX_ANNOTATIONS
+  )
+
+  // ── Snapshot the version ─────────────────────────────────────────────────────
+  const { data: last } = await supabase
+    .from('piece_drafts')
+    .select('version')
+    .eq('piece_id', pieceId)
+    .order('version', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  const version = ((last as { version: number } | null)?.version ?? 0) + 1
+  const wordCount = trimmed ? trimmed.split(/\s+/).length : 0
+
+  const { data: draft, error: draftErr } = await supabase
+    .from('piece_drafts')
+    .insert({
+      piece_id: pieceId,
+      user_id: user.id,
+      version,
+      content: draftContent,
+      word_count: wordCount,
+    })
+    .select('id')
+    .single()
+  if (draftErr || !draft) {
+    console.error('[interlocutor/annotate] draft insert failed:', draftErr?.message)
+    return NextResponse.json({ error: 'Could not save the draft version' }, { status: 500 })
+  }
+  const draftId = (draft as { id: string }).id
+
+  // ── Locate offsets and persist annotations ───────────────────────────────────
+  // Locate against the exact submitted content (not the trimmed copy) so offsets
+  // index the stored version. A found quote advances the search cursor so repeated
+  // phrases anchor left-to-right rather than all onto the first occurrence.
+  let cursor = 0
+  const rows = rawAnnotations.map(a => {
+    const span = locate(draftContent, a.quote ?? '', cursor)
+    if (span) cursor = span.start + 1
+    return {
+      draft_id: draftId,
+      user_id: user.id,
+      start_offset: span ? span.start : null,
+      end_offset: span ? span.end : null,
+      quote: a.quote ?? '',
+      dimension: a.dimension,
+      severity: a.severity,
+      comment: a.comment ?? '',
+      suggestion: a.suggestion ?? null,
+    }
+  })
+
+  let stored: StoredAnnotation[] = []
+  if (rows.length) {
+    const { data: inserted, error: annErr } = await supabase
+      .from('draft_annotations')
+      .insert(rows)
+      .select('id, start_offset, end_offset, quote, dimension, severity, comment, suggestion, status')
+    if (annErr) {
+      console.error('[interlocutor/annotate] annotation insert failed:', annErr.message)
+    } else {
+      stored = (inserted as StoredAnnotation[]) ?? []
+    }
+  }
+
+  // ── Feed the profile: one critique_history row per pass ───────────────────────
+  const dimensions = [
+    ...new Set(
+      [
+        ...(Array.isArray(parsed.dimensions_flagged) ? parsed.dimensions_flagged : []),
+        ...rawAnnotations.map(a => a.dimension),
+      ]
+        .filter((d): d is string => typeof d === 'string')
+        .filter(d => (RUBRIC_DIMENSIONS as readonly string[]).includes(d))
+    ),
+  ]
+
+  const historyText = [
+    summary,
+    '',
+    ...rawAnnotations.map(a => {
+      const head = `- [${a.severity}/${a.dimension}] "${(a.quote ?? '').slice(0, 120)}"`
+      const sugg = a.suggestion ? ` (suggested rewrite offered)` : ''
+      return `${head}: ${a.comment}${sugg}`
+    }),
+  ].join('\n')
+
+  const { error: histErr } = await supabase.from('critique_history').insert({
+    user_id: user.id,
+    excerpt: draftContent,
+    dimensions_flagged: dimensions,
+    critique: historyText,
+    piece_title: title,
+  })
+  const recorded = !histErr
+  if (histErr) {
+    console.error('[interlocutor/annotate] history insert failed:', histErr.message)
+  }
+
+  // Located annotations carry offsets; unlocated ones ride back as general notes.
+  const annotations = stored.filter(a => a.start_offset !== null && a.end_offset !== null)
+  const generalNotes = stored.filter(a => a.start_offset === null || a.end_offset === null)
+
+  return NextResponse.json({
+    pieceId,
+    draftId,
+    version,
+    summary,
+    annotations,
+    generalNotes,
+    recorded,
+  })
+}

--- a/academy/web/src/app/dashboard/composer/page.tsx
+++ b/academy/web/src/app/dashboard/composer/page.tsx
@@ -1,28 +1,37 @@
 'use client';
 
-// The composer — the Interlocutor's only surface. A long-form editor and one
-// explicit invocation. No ambient flagging, no inline suggestions, no
-// autocomplete: the agent speaks when asked and not otherwise.
+// The composer — the Interlocutor Studio. A long-form editor and one explicit
+// invocation, as before, but the response is now marked up in place: the draft
+// is snapshotted as an immutable version and returned with annotations anchored
+// to the sentences that earned them, colored by severity, some carrying a
+// concrete rewrite the student accepts or rejects.
 //
-// Paste and drop are permitted: drafts written elsewhere can be brought in.
-// (The editor once blocked insertion so revisions had to be typed; that
-// mechanism was lifted deliberately.)
+// The loop the studio adds: write -> submit for markup -> accept/dismiss and
+// revise -> submit again as the next version, with the version rail showing the
+// argument getting less red over time. Revision happens back in the textarea
+// (academy has no rich-text editor), so accepting a rewrite repopulates the
+// editor rather than mutating the reviewed snapshot.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabase';
-import {
-  CritiqueBody,
-  DimensionChips,
-  InterlocutorChat,
-  MIN_CRITIQUE_CHARS as MIN_CHARS,
-  type CritiqueResult,
-} from '@/components/InterlocutorPanel';
-
-type Mode = 'full' | 'structural';
+import { InterlocutorChat, MIN_CRITIQUE_CHARS as MIN_CHARS } from '@/components/InterlocutorPanel';
+import { MarkedUpDraft, type Annotation } from '@/components/MarkedUpDraft';
+import { DraftHistory, type DraftSummary } from '@/components/DraftHistory';
+import { applyAccepted, type AcceptedEdit } from '@/lib/annotations';
 
 const DRAFT_KEY = 'interlocutor-draft';
 const TITLE_KEY = 'interlocutor-draft-title';
+const PIECE_KEY = 'interlocutor-piece-id';
+
+interface ReviewData {
+  draftId: string;
+  version: number;
+  content: string;
+  summary: string;
+  annotations: Annotation[];
+  generalNotes: Annotation[];
+}
 
 export default function ComposerPage() {
   const router = useRouter();
@@ -31,29 +40,72 @@ export default function ComposerPage() {
   const [loaded, setLoaded] = useState(false);
   const [title, setTitle] = useState('');
   const [text, setText] = useState('');
-  const [selection, setSelection] = useState({ start: 0, end: 0 });
-  const [mode, setMode] = useState<Mode>('full');
+  const [pieceId, setPieceId] = useState<string | null>(null);
+
+  const [view, setView] = useState<'editor' | 'review'>('editor');
+  const [review, setReview] = useState<ReviewData | null>(null);
+  // The draft produced by this session's latest submit is editable; a version
+  // opened from the rail is read-only.
+  const [liveDraftId, setLiveDraftId] = useState<string | null>(null);
+  const [history, setHistory] = useState<DraftSummary[]>([]);
 
   const [working, setWorking] = useState(false);
-  const [result, setResult] = useState<CritiqueResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
 
-  // ── Auth + draft restore ───────────────────────────────────────────────────
+  // ── Load the draft's version rail for the rail + counts ──────────────────────
+  const loadHistory = useCallback(async (pid: string) => {
+    const { data: drafts } = await supabase
+      .from('piece_drafts')
+      .select('id, version, created_at, word_count')
+      .eq('piece_id', pid)
+      .order('version', { ascending: false });
+    const rows = (drafts as { id: string; version: number; created_at: string; word_count: number }[]) ?? [];
+    if (rows.length === 0) {
+      setHistory([]);
+      return;
+    }
+    const ids = rows.map(r => r.id);
+    const { data: anns } = await supabase
+      .from('draft_annotations')
+      .select('draft_id, severity')
+      .in('draft_id', ids);
+    const tally: Record<string, Record<string, number>> = {};
+    for (const a of (anns as { draft_id: string; severity: string }[]) ?? []) {
+      (tally[a.draft_id] ??= {})[a.severity] = ((tally[a.draft_id] ??= {})[a.severity] ?? 0) + 1;
+    }
+    setHistory(
+      rows.map(r => ({
+        id: r.id,
+        version: r.version,
+        created_at: r.created_at,
+        wordCount: r.word_count,
+        counts: tally[r.id] ?? {},
+      }))
+    );
+  }, []);
+
+  // ── Auth + restore ───────────────────────────────────────────────────────────
   useEffect(() => {
     let cancelled = false;
     (async () => {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) { router.replace('/login'); return; }
       if (cancelled) return;
+      let pid: string | null = null;
       try {
         setText(localStorage.getItem(DRAFT_KEY) ?? '');
         setTitle(localStorage.getItem(TITLE_KEY) ?? '');
+        pid = localStorage.getItem(PIECE_KEY);
       } catch {}
+      if (pid) {
+        setPieceId(pid);
+        await loadHistory(pid);
+      }
       setLoaded(true);
     })();
     return () => { cancelled = true; };
-  }, [router]);
+  }, [router, loadHistory]);
 
   const handleTextChange = (v: string) => {
     setText(v);
@@ -64,55 +116,143 @@ export default function ComposerPage() {
     try { localStorage.setItem(TITLE_KEY, v); } catch {}
   };
 
-  const trackSelection = useCallback(() => {
-    const el = editorRef.current;
-    if (!el) return;
-    setSelection({ start: el.selectionStart, end: el.selectionEnd });
-  }, []);
-
-  const selected = text.slice(selection.start, selection.end).trim();
-  const hasSelection = selected.length >= MIN_CHARS;
-  const submission = hasSelection ? selected : text.trim();
+  const submission = text.trim();
   const canSubmit = submission.length >= MIN_CHARS && !working;
+  const words = useMemo(() => (submission ? submission.split(/\s+/).length : 0), [submission]);
 
-  const words = useMemo(
-    () => (text.trim() ? text.trim().split(/\s+/).length : 0),
-    [text]
-  );
-
+  // ── Submit for markup ─────────────────────────────────────────────────────────
   const invoke = async () => {
     if (!canSubmit) return;
     setWorking(true);
     setError(null);
-    setResult(null);
+    setNotice(null);
     try {
-      const res = await fetch('/api/interlocutor/critique', {
+      const res = await fetch('/api/interlocutor/annotate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          excerpt: submission,
-          scope: hasSelection ? 'selection' : 'document',
-          documentContext: hasSelection ? text : undefined,
-          pieceTitle: title.trim() || undefined,
-          mode,
+          pieceId: pieceId || undefined,
+          title: title.trim() || undefined,
+          draftContent: text,
         }),
       });
       const data: unknown = await res.json();
       if (!res.ok) {
-        const msg = (data as { error?: string }).error;
-        setError(msg ?? 'The Interlocutor is unavailable.');
+        setError((data as { error?: string }).error ?? 'The Interlocutor is unavailable.');
         return;
       }
-      const d = data as CritiqueResult;
-      setResult(d);
+      const d = data as {
+        pieceId: string;
+        draftId: string;
+        version: number;
+        summary: string;
+        annotations: Annotation[];
+        generalNotes: Annotation[];
+        recorded: boolean;
+      };
+      setPieceId(d.pieceId);
+      try { localStorage.setItem(PIECE_KEY, d.pieceId); } catch {}
+      setReview({
+        draftId: d.draftId,
+        version: d.version,
+        content: text,
+        summary: d.summary,
+        annotations: d.annotations ?? [],
+        generalNotes: d.generalNotes ?? [],
+      });
+      setLiveDraftId(d.draftId);
+      setView('review');
       if (!d.recorded) {
-        setNotice('This critique was not written to your history, so it will not shape your profile.');
+        setNotice('This pass was not written to your history, so it will not shape your profile.');
       }
+      await loadHistory(d.pieceId);
     } catch {
       setError('The Interlocutor could not be reached.');
     } finally {
       setWorking(false);
     }
+  };
+
+  // ── Accept / dismiss on the live draft ────────────────────────────────────────
+  const setAnnStatus = async (a: Annotation, status: 'accepted' | 'dismissed') => {
+    setReview(prev =>
+      prev
+        ? {
+            ...prev,
+            annotations: prev.annotations.map(x => (x.id === a.id ? { ...x, status } : x)),
+            generalNotes: prev.generalNotes.map(x => (x.id === a.id ? { ...x, status } : x)),
+          }
+        : prev
+    );
+    const { error: upErr } = await supabase
+      .from('draft_annotations')
+      .update({ status })
+      .eq('id', a.id);
+    if (upErr) {
+      setNotice('That change did not save. It will apply here but may not persist.');
+    }
+  };
+
+  const acceptedEdits: AcceptedEdit[] = useMemo(() => {
+    if (!review) return [];
+    return review.annotations
+      .filter(a => a.status === 'accepted' && a.start_offset !== null && a.end_offset !== null && a.suggestion)
+      .map(a => ({
+        start: a.start_offset as number,
+        end: a.end_offset as number,
+        suggestion: a.suggestion as string,
+      }));
+  }, [review]);
+
+  // Carry the reviewed version (with accepted rewrites spliced in) back into the
+  // editor. The next submit becomes the following version.
+  const reviseInEditor = () => {
+    if (!review) return;
+    const revised = applyAccepted(review.content, acceptedEdits);
+    handleTextChange(revised);
+    setView('editor');
+    setNotice(
+      acceptedEdits.length
+        ? `${acceptedEdits.length} accepted rewrite${acceptedEdits.length === 1 ? '' : 's'} applied. Keep revising, then submit again for the next draft.`
+        : 'Back in the editor. Keep revising, then submit again for the next draft.'
+    );
+  };
+
+  // ── Open a past version from the rail (read-only) ──────────────────────────────
+  const openDraft = async (draftId: string) => {
+    setError(null);
+    const { data: draft } = await supabase
+      .from('piece_drafts')
+      .select('id, version, content')
+      .eq('id', draftId)
+      .maybeSingle();
+    if (!draft) { setError('That draft could not be opened.'); return; }
+    const d = draft as { id: string; version: number; content: string };
+    const { data: anns } = await supabase
+      .from('draft_annotations')
+      .select('id, start_offset, end_offset, quote, dimension, severity, comment, suggestion, status')
+      .eq('draft_id', draftId);
+    const all = (anns as Annotation[]) ?? [];
+    setReview({
+      draftId: d.id,
+      version: d.version,
+      content: d.content,
+      summary: '',
+      annotations: all.filter(a => a.start_offset !== null),
+      generalNotes: all.filter(a => a.start_offset === null),
+    });
+    setView('review');
+  };
+
+  const newPiece = () => {
+    setPieceId(null);
+    setReview(null);
+    setLiveDraftId(null);
+    setHistory([]);
+    setView('editor');
+    handleTitleChange('');
+    handleTextChange('');
+    try { localStorage.removeItem(PIECE_KEY); } catch {}
   };
 
   if (!loaded) {
@@ -123,132 +263,148 @@ export default function ComposerPage() {
     );
   }
 
+  const reviewReadOnly = review ? review.draftId !== liveDraftId : true;
+
   return (
-    <div className="max-w-3xl">
-      <header className="mb-8">
-        <p className="font-mono text-academy-gold text-xs uppercase tracking-[0.3em] mb-2">
-          The Interlocutor
-        </p>
-        <p className="text-academy-muted text-sm leading-relaxed">
-          Write the argument. Select a passage and ask, or ask on the whole draft.
-          The Interlocutor will not write a sentence for you.
-        </p>
+    <div className="max-w-6xl">
+      <header className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <p className="font-mono text-academy-gold text-xs uppercase tracking-[0.3em] mb-2">
+            The Interlocutor
+          </p>
+          <p className="text-academy-muted text-sm leading-relaxed max-w-2xl">
+            Write the argument, then submit it for markup. The Interlocutor returns your
+            draft marked up in place: each judgment fastened to the sentence that earned it,
+            colored by how much it costs the argument. Where a fix is better shown than
+            described, it offers a rewrite you can accept or reject. Revise, and submit again.
+          </p>
+        </div>
+        {(pieceId || text.trim()) && (
+          <button
+            onClick={newPiece}
+            className="flex-shrink-0 font-mono text-[10px] uppercase tracking-wider text-academy-muted hover:text-academy-text border border-academy-border rounded px-3 py-1.5"
+          >
+            New piece
+          </button>
+        )}
       </header>
 
-      {/* ── The editor ──────────────────────────────────────────────────────── */}
-      <input
-        className="w-full bg-transparent border-b border-academy-border focus:border-academy-gold focus:outline-none font-serif text-academy-text text-2xl pb-2 mb-6 placeholder-academy-muted"
-        placeholder="Untitled"
-        value={title}
-        onChange={e => handleTitleChange(e.target.value)}
-      />
+      <div className="grid grid-cols-1 lg:grid-cols-[1fr_240px] gap-8 items-start">
+        <div className="min-w-0">
+          {view === 'editor' ? (
+            <>
+              <input
+                className="w-full bg-transparent border-b border-academy-border focus:border-academy-gold focus:outline-none font-serif text-academy-text text-2xl pb-2 mb-6 placeholder-academy-muted"
+                placeholder="Untitled"
+                value={title}
+                onChange={e => handleTitleChange(e.target.value)}
+              />
 
-      <textarea
-        ref={editorRef}
-        className="w-full min-h-[55vh] bg-navy border border-academy-border rounded-lg px-5 py-4 font-serif text-academy-text text-[15px] leading-[1.8] placeholder-academy-muted focus:border-academy-gold focus:outline-none resize-y"
-        placeholder="Begin."
-        value={text}
-        onChange={e => handleTextChange(e.target.value)}
-        onSelect={trackSelection}
-        onKeyUp={trackSelection}
-        onMouseUp={trackSelection}
-      />
+              <textarea
+                ref={editorRef}
+                className="w-full min-h-[55vh] bg-navy border border-academy-border rounded-lg px-5 py-4 font-serif text-academy-text text-[15px] leading-[1.8] placeholder-academy-muted focus:border-academy-gold focus:outline-none resize-y"
+                placeholder="Begin."
+                value={text}
+                onChange={e => handleTextChange(e.target.value)}
+              />
 
-      <div className="flex items-center justify-between mt-2 text-xs text-academy-muted font-mono">
-        <span>{words} word{words === 1 ? '' : 's'}</span>
-        <span>
-          {hasSelection
-            ? `${selected.split(/\s+/).length} words selected`
-            : selection.end > selection.start
-              ? 'selection too short to judge'
-              : 'no selection'}
-        </span>
-      </div>
+              <div className="flex items-center justify-between mt-2 text-xs text-academy-muted font-mono">
+                <span>{words} word{words === 1 ? '' : 's'}</span>
+                {review && (
+                  <button onClick={() => setView('review')} className="hover:text-academy-text">
+                    ← back to the markup
+                  </button>
+                )}
+              </div>
 
-      {notice && (
-        <p className="text-academy-gold text-xs mt-3 leading-relaxed">{notice}</p>
-      )}
+              <div className="mt-8 border-t border-academy-gold/20 pt-6 flex flex-wrap items-center gap-4">
+                <button
+                  onClick={invoke}
+                  disabled={!canSubmit}
+                  className="bg-academy-gold text-academy-bg font-semibold rounded-lg px-6 py-3 text-sm hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  {working ? 'Reading…' : review ? 'Submit the next draft' : 'Submit for markup'}
+                </button>
+                {submission.length > 0 && submission.length < MIN_CHARS && (
+                  <span className="text-academy-muted text-xs">Too little to judge.</span>
+                )}
+              </div>
+            </>
+          ) : (
+            review && (
+              <>
+                <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
+                  <div className="flex items-center gap-3">
+                    <span className="font-mono text-academy-gold text-xs uppercase tracking-widest">
+                      Draft v{review.version}
+                    </span>
+                    {reviewReadOnly && (
+                      <span className="font-mono text-[10px] uppercase tracking-wider text-academy-muted">
+                        read-only
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-3">
+                    {!reviewReadOnly && (
+                      <button
+                        onClick={reviseInEditor}
+                        className="bg-academy-gold text-academy-bg font-semibold rounded-lg px-4 py-2 text-xs hover:opacity-90"
+                      >
+                        {acceptedEdits.length
+                          ? `Apply ${acceptedEdits.length} & revise`
+                          : 'Revise in editor'}
+                      </button>
+                    )}
+                    <button
+                      onClick={() => setView('editor')}
+                      className="border border-academy-border text-academy-muted hover:text-academy-text rounded-lg px-4 py-2 text-xs"
+                    >
+                      To editor
+                    </button>
+                  </div>
+                </div>
 
-      {/* ── Invocation ──────────────────────────────────────────────────────── */}
-      <div className="mt-8 border-t border-academy-gold/20 pt-6 flex flex-wrap items-center gap-4">
-        <button
-          onClick={invoke}
-          disabled={!canSubmit}
-          className="bg-academy-gold text-academy-bg font-semibold rounded-lg px-6 py-3 text-sm hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
-        >
-          {working
-            ? 'Reading…'
-            : hasSelection
-              ? 'Submit the selection'
-              : 'Submit the draft'}
-        </button>
+                <MarkedUpDraft
+                  content={review.content}
+                  annotations={review.annotations}
+                  generalNotes={review.generalNotes}
+                  summary={review.summary || undefined}
+                  readOnly={reviewReadOnly}
+                  onAccept={a => setAnnStatus(a, 'accepted')}
+                  onDismiss={a => setAnnStatus(a, 'dismissed')}
+                />
+              </>
+            )
+          )}
 
-        <div className="flex items-center gap-1 text-xs font-mono">
-          {(['full', 'structural'] as Mode[]).map(m => (
-            <button
-              key={m}
-              onClick={() => setMode(m)}
-              className={`px-3 py-1.5 rounded border transition-colors ${
-                mode === m
-                  ? 'border-academy-gold text-academy-gold'
-                  : 'border-academy-border text-academy-muted hover:text-academy-text'
-              }`}
-            >
-              {m === 'full' ? 'Full critique' : 'Structural pass'}
-            </button>
-          ))}
+          {notice && <p className="text-academy-gold text-xs mt-4 leading-relaxed">{notice}</p>}
+          {error && <p className="text-red-400 text-xs mt-4">{error}</p>}
         </div>
 
-        {submission.length > 0 && submission.length < MIN_CHARS && (
-          <span className="text-academy-muted text-xs">
-            Too little to judge.
-          </span>
-        )}
+        {/* ── The version rail ─────────────────────────────────────────────── */}
+        <div className="lg:sticky lg:top-4">
+          <DraftHistory
+            versions={history}
+            activeDraftId={review?.draftId ?? null}
+            onSelect={openDraft}
+          />
+        </div>
       </div>
 
-      {error && <p className="text-red-400 text-xs mt-4">{error}</p>}
-
-      {/* ── The critique ────────────────────────────────────────────────────── */}
-      {result && (
-        <section className="mt-12 border-l-2 border-academy-gold pl-6">
-          <div className="flex flex-wrap items-center gap-2 mb-6">
-            <p className="font-mono text-academy-gold text-xs uppercase tracking-widest mr-2">
-              The Interlocutor
-            </p>
-            <DimensionChips dimensions={result.dimensions_flagged} />
-          </div>
-          <CritiqueBody critique={result.critique} />
-        </section>
-      )}
-
-      {/* ── Conversation ────────────────────────────────────────────────────────
-          Available with or without a critique: a question about a paragraph you
-          are stuck on should not require submitting the whole draft first. It
-          stays anchored to the draft either way, and inherits the critique as
-          context once one exists. */}
-      <section className="mt-12 border-t border-academy-gold/20 pt-6">
-        <p className="font-mono text-academy-gold text-xs uppercase tracking-widest mb-4">
-          {result ? 'Continue' : 'Ask'}
-        </p>
+      {/* ── Conversation, anchored to the draft ──────────────────────────────── */}
+      <section className="mt-12 border-t border-academy-gold/20 pt-6 max-w-3xl">
+        <p className="font-mono text-academy-gold text-xs uppercase tracking-widest mb-4">Ask</p>
         {text.trim().length >= MIN_CHARS ? (
           <InterlocutorChat
-            key={result?.id ?? 'no-critique'}
-            excerpt={hasSelection ? selected : text}
-            critique={result?.critique}
-            critiqueId={result?.id}
+            key={review?.draftId ?? 'no-draft'}
+            excerpt={review?.content ?? text}
             pieceTitle={title}
-            placeholder={
-              result
-                ? 'Push back, or ask what a judgment meant…'
-                : 'Ask about the draft. It will not write a sentence for you…'
-            }
+            placeholder="Ask about the draft, or push back on a judgment…"
           />
         ) : (
-          // The heading stays even when the box cannot. Hiding the section
-          // outright left nothing on the page to explain the absence.
           <p className="text-academy-muted text-sm leading-relaxed">
-            The conversation is anchored to the draft, so it opens once there is
-            a draft to anchor it to. Write a few sentences above.
+            The conversation is anchored to the draft, so it opens once there is a draft to
+            anchor it to. Write a few sentences above.
           </p>
         )}
       </section>

--- a/academy/web/src/components/DraftHistory.tsx
+++ b/academy/web/src/components/DraftHistory.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+// The version rail. Each submission for markup snapshots an immutable draft; this
+// lists them newest first with a severity tally, and lets the student open any
+// past version's markup read-only. This is the visible half of "iterate through
+// drafts": you can see the argument getting less red over time.
+
+import { SEVERITY } from '@/components/MarkedUpDraft';
+
+export interface DraftSummary {
+  id: string;
+  version: number;
+  created_at: string;
+  wordCount: number;
+  counts: Record<string, number>; // severity -> count
+}
+
+const ORDER = ['critical', 'major', 'minor', 'note', 'strength'] as const;
+
+function when(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) +
+      ', ' + d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+  } catch {
+    return '';
+  }
+}
+
+export function DraftHistory({
+  versions,
+  activeDraftId,
+  onSelect,
+}: {
+  versions: DraftSummary[];
+  activeDraftId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  if (versions.length === 0) return null;
+
+  return (
+    <div>
+      <p className="font-mono text-academy-gold text-[10px] uppercase tracking-widest mb-3">
+        Drafts
+      </p>
+      <div className="space-y-1.5">
+        {versions.map(v => {
+          const isActive = v.id === activeDraftId;
+          const pips = ORDER.filter(s => (v.counts[s] ?? 0) > 0);
+          return (
+            <button
+              key={v.id}
+              onClick={() => onSelect(v.id)}
+              className={`w-full text-left rounded-lg border px-3 py-2.5 transition-colors ${
+                isActive
+                  ? 'border-academy-gold bg-academy-gold/10'
+                  : 'border-academy-border hover:border-academy-gold/50'
+              }`}
+            >
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="font-serif text-academy-text text-sm">
+                  Draft v{v.version}
+                </span>
+                <span className="font-mono text-academy-muted text-[10px]">{when(v.created_at)}</span>
+              </div>
+              <div className="flex items-center gap-2.5 mt-1.5 flex-wrap">
+                {pips.length === 0 ? (
+                  <span className="font-mono text-academy-muted text-[10px]">no marks</span>
+                ) : (
+                  pips.map(s => (
+                    <span key={s} className="flex items-center gap-1" title={SEVERITY[s].label}>
+                      <span
+                        className="inline-block w-1.5 h-1.5 rounded-full"
+                        style={{ background: SEVERITY[s].color }}
+                      />
+                      <span className="font-mono text-academy-muted text-[10px]">
+                        {v.counts[s]}
+                      </span>
+                    </span>
+                  ))
+                )}
+                <span className="font-mono text-academy-muted text-[10px] ml-auto">
+                  {v.wordCount} words
+                </span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/academy/web/src/components/MarkedUpDraft.tsx
+++ b/academy/web/src/components/MarkedUpDraft.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+// The review view: an immutable draft version rendered with the Interlocutor's
+// annotations as colored, clickable spans, beside a margin of comment cards.
+// There is no rich-text editor here on purpose (academy has none) — this reads a
+// snapshot, and revision happens by accepting suggestions or editing back in the
+// composer, which produces a new version.
+//
+// Presentational: it owns only which annotation is highlighted. Accept / dismiss
+// and the working-copy splice belong to the page, so one place owns the draft.
+
+import { useState } from 'react';
+import { buildSegments, type SpanInput } from '@/lib/annotations';
+import { DimensionChips } from '@/components/InterlocutorPanel';
+
+export interface Annotation {
+  id: string;
+  start_offset: number | null;
+  end_offset: number | null;
+  quote: string;
+  dimension: string;
+  severity: string;
+  comment: string;
+  suggestion: string | null;
+  status: string; // open | accepted | dismissed
+}
+
+// Tuned for the navy (#0A1628) dark surface. Background rides at low alpha; the
+// underline and dot use the full color.
+export const SEVERITY: Record<string, { color: string; label: string; rank: number }> = {
+  critical: { color: '#E06B6B', label: 'Critical', rank: 5 },
+  major: { color: '#C9A84C', label: 'Major', rank: 4 },
+  minor: { color: '#6B9BD1', label: 'Minor', rank: 3 },
+  note: { color: '#7A8FA6', label: 'Note', rank: 2 },
+  strength: { color: '#6BBF8A', label: 'Strength', rank: 1 },
+};
+const sevOf = (s: string) => SEVERITY[s] ?? SEVERITY.note;
+
+function SeverityDot({ severity }: { severity: string }) {
+  return (
+    <span
+      className="inline-block w-2 h-2 rounded-full flex-shrink-0"
+      style={{ background: sevOf(severity).color }}
+      aria-hidden
+    />
+  );
+}
+
+export function MarkedUpDraft({
+  content,
+  annotations,
+  generalNotes = [],
+  summary,
+  readOnly = false,
+  onAccept,
+  onDismiss,
+}: {
+  content: string;
+  annotations: Annotation[];
+  generalNotes?: Annotation[];
+  summary?: string;
+  readOnly?: boolean;
+  onAccept?: (a: Annotation) => void;
+  onDismiss?: (a: Annotation) => void;
+}) {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  // Only open, located annotations get an inline highlight. Accepted or dismissed
+  // ones drop out of the text (the student has dealt with them) but remain in the
+  // margin as a record.
+  const inline = annotations.filter(
+    a => a.start_offset !== null && a.end_offset !== null && a.status === 'open'
+  );
+  const spans: SpanInput[] = inline.map(a => ({
+    id: a.id,
+    start: a.start_offset as number,
+    end: a.end_offset as number,
+    severity: a.severity,
+  }));
+  const segments = buildSegments(content, spans);
+
+  // Margin order: gravest first, then document position.
+  const ordered = [...annotations].sort(
+    (a, b) =>
+      sevOf(b.severity).rank - sevOf(a.severity).rank ||
+      (a.start_offset ?? 1e9) - (b.start_offset ?? 1e9)
+  );
+
+  const focus = (id: string) => {
+    setActiveId(id);
+    const el = document.getElementById(`card-${id}`);
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  };
+  const focusSpan = (id: string) => {
+    setActiveId(id);
+    const el = document.getElementById(`hl-${id}`);
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  };
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-[1fr_360px] gap-8 items-start">
+      {/* ── The marked-up text ─────────────────────────────────────────────── */}
+      <article className="font-serif text-academy-text text-[16px] leading-[1.9] whitespace-pre-wrap">
+        {summary && (
+          <p className="mb-6 pb-5 border-b border-academy-gold/25 text-academy-muted text-[15px] leading-relaxed not-italic">
+            <span className="font-mono text-academy-gold text-[10px] uppercase tracking-widest block mb-1.5">
+              The central problem
+            </span>
+            {summary}
+          </p>
+        )}
+        {segments.map((seg, i) => {
+          if (!seg.annId) return <span key={i}>{seg.text}</span>;
+          const sev = sevOf(seg.severity ?? 'note');
+          const isActive = seg.annId === activeId;
+          return (
+            <span
+              key={i}
+              id={`hl-${seg.annId}`}
+              onClick={() => focus(seg.annId as string)}
+              className="cursor-pointer rounded-sm transition-colors"
+              style={{
+                borderBottom: `2px solid ${sev.color}`,
+                background: `${sev.color}${isActive ? '3a' : '1e'}`,
+              }}
+              title={`${sev.label}: ${seg.severity}`}
+            >
+              {seg.text}
+            </span>
+          );
+        })}
+      </article>
+
+      {/* ── The margin ─────────────────────────────────────────────────────── */}
+      <aside className="lg:sticky lg:top-4 space-y-3">
+        {ordered.length === 0 && generalNotes.length === 0 && (
+          <p className="font-serif italic text-academy-muted text-sm">
+            Nothing marked. Either the draft holds, or there was too little to judge.
+          </p>
+        )}
+
+        {ordered.map(a => {
+          const sev = sevOf(a.severity);
+          const isActive = a.id === activeId;
+          const dealt = a.status !== 'open';
+          return (
+            <div
+              key={a.id}
+              id={`card-${a.id}`}
+              onClick={() => a.start_offset !== null && focusSpan(a.id)}
+              className="rounded-lg border p-3.5 transition-colors"
+              style={{
+                borderColor: isActive ? sev.color : 'rgba(30,50,88,0.9)',
+                background: isActive ? `${sev.color}12` : 'rgba(15,30,56,0.5)',
+                cursor: a.start_offset !== null ? 'pointer' : 'default',
+                opacity: dealt ? 0.55 : 1,
+              }}
+            >
+              <div className="flex items-center gap-2 mb-2">
+                <SeverityDot severity={a.severity} />
+                <span
+                  className="font-mono text-[10px] uppercase tracking-wider"
+                  style={{ color: sev.color }}
+                >
+                  {sev.label}
+                </span>
+                <DimensionChips dimensions={[a.dimension]} />
+                {a.start_offset === null && (
+                  <span className="font-mono text-[9px] uppercase tracking-wider text-academy-muted ml-auto">
+                    general
+                  </span>
+                )}
+                {dealt && (
+                  <span className="font-mono text-[9px] uppercase tracking-wider text-academy-muted ml-auto">
+                    {a.status}
+                  </span>
+                )}
+              </div>
+
+              {a.start_offset === null && a.quote && (
+                <p className="font-serif italic text-academy-muted text-[13px] mb-1.5 leading-snug">
+                  &ldquo;{a.quote.slice(0, 140)}
+                  {a.quote.length > 140 ? '…' : ''}&rdquo;
+                </p>
+              )}
+
+              <p className="font-serif text-academy-text text-[14px] leading-relaxed">
+                {a.comment}
+              </p>
+
+              {a.suggestion && (
+                <div className="mt-2.5 pt-2.5 border-t border-academy-border">
+                  <span className="font-mono text-[9px] uppercase tracking-wider text-academy-muted block mb-1">
+                    Suggested rewrite
+                  </span>
+                  <p className="font-serif text-academy-gold text-[14px] leading-relaxed">
+                    {a.suggestion}
+                  </p>
+                  {!readOnly && a.status === 'open' && (
+                    <div className="flex gap-2 mt-2.5">
+                      <button
+                        onClick={e => {
+                          e.stopPropagation();
+                          onAccept?.(a);
+                        }}
+                        className="bg-academy-gold text-academy-bg font-semibold rounded px-3 py-1.5 text-xs hover:opacity-90"
+                      >
+                        Accept
+                      </button>
+                      <button
+                        onClick={e => {
+                          e.stopPropagation();
+                          onDismiss?.(a);
+                        }}
+                        className="border border-academy-border text-academy-muted hover:text-academy-text rounded px-3 py-1.5 text-xs"
+                      >
+                        Dismiss
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* A diagnosis with no rewrite can still be dismissed once addressed. */}
+              {!a.suggestion && !readOnly && a.status === 'open' && (
+                <button
+                  onClick={e => {
+                    e.stopPropagation();
+                    onDismiss?.(a);
+                  }}
+                  className="mt-2 font-mono text-[10px] uppercase tracking-wider text-academy-muted hover:text-academy-text"
+                >
+                  Mark addressed
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </aside>
+    </div>
+  );
+}

--- a/academy/web/src/lib/annotations.ts
+++ b/academy/web/src/lib/annotations.ts
@@ -1,0 +1,186 @@
+// Pure, I/O-free helpers for the Interlocutor's marked-up pass: locating the
+// model's verbatim quotes in a draft, resolving overlapping spans into flat
+// render segments, and applying accepted rewrites.
+//
+// Kept out of the route so the server (which locates offsets) and a test can
+// exercise them without a database or a model. The model returns a verbatim
+// `quote`; it is never trusted to count characters, so every offset is derived
+// here from the text itself.
+
+export interface LocatedSpan {
+  start: number
+  end: number
+}
+
+// Collapse runs of whitespace to a single space so a quote that differs from the
+// draft only in spacing (a wrapped newline, a doubled space) still matches. The
+// map records, for each normalized character, its index in the original string.
+function buildNormIndex(content: string): { norm: string; map: number[] } {
+  let norm = ''
+  const map: number[] = []
+  let prevSpace = false
+  for (let i = 0; i < content.length; i++) {
+    const ch = content[i]
+    if (/\s/.test(ch)) {
+      if (!prevSpace) {
+        norm += ' '
+        map.push(i)
+        prevSpace = true
+      }
+      // additional whitespace in the run is dropped
+    } else {
+      norm += ch
+      map.push(i)
+      prevSpace = false
+    }
+  }
+  return { norm, map }
+}
+
+function normalizeWs(s: string): string {
+  return s.replace(/\s+/g, ' ')
+}
+
+// Locate `quote` in `content`. Three passes, most-exact first:
+//   1. exact substring
+//   2. whitespace-normalized substring, mapped back to real offsets
+//   3. fuzzy: the first 40 characters of the quote, exact
+// Returns null when none place it; the caller surfaces those as general notes
+// rather than inline highlights, so nothing the model said is silently dropped.
+export function locate(content: string, quote: string, fromIndex = 0): LocatedSpan | null {
+  const q = quote.trim()
+  if (!q) return null
+
+  // 1. exact
+  const exact = content.indexOf(q, fromIndex)
+  if (exact !== -1) return { start: exact, end: exact + q.length }
+
+  // 2. whitespace-normalized
+  const normQuote = normalizeWs(q)
+  const { norm, map } = buildNormIndex(content)
+  const nIdx = norm.indexOf(normQuote)
+  if (nIdx !== -1) {
+    const start = map[nIdx]
+    const endNorm = nIdx + normQuote.length - 1
+    const end = map[endNorm] + 1
+    if (typeof start === 'number' && typeof end === 'number' && end > start) {
+      return { start, end }
+    }
+  }
+
+  // 3. fuzzy anchor: first 40 chars, exact. Enough to place a long quote whose
+  // tail the model altered; too short an anchor would mislocate, so require 12+.
+  const anchor = q.slice(0, 40)
+  if (anchor.length >= 12) {
+    const a = content.indexOf(anchor, fromIndex)
+    if (a !== -1) return { start: a, end: a + anchor.length }
+  }
+
+  return null
+}
+
+// ── Rendering ────────────────────────────────────────────────────────────────
+
+const SEVERITY_RANK: Record<string, number> = {
+  critical: 5,
+  major: 4,
+  minor: 3,
+  note: 2,
+  strength: 1,
+}
+function rank(sev: string | null | undefined): number {
+  return sev ? SEVERITY_RANK[sev] ?? 0 : 0
+}
+
+export interface SpanInput {
+  id: string
+  start: number
+  end: number
+  severity: string
+}
+
+export interface Segment {
+  text: string
+  start: number
+  end: number
+  annId: string | null
+  severity: string | null
+}
+
+// Flatten overlapping annotation spans into a non-overlapping, ordered list of
+// text segments for rendering. Where spans overlap, the higher-severity span
+// wins the covered characters (ties keep the earlier span, since a later equal
+// span cannot outrank it). Uncovered characters become plain segments with a
+// null annId. The union of segment texts always reconstructs `content`.
+export function buildSegments(content: string, spans: SpanInput[]): Segment[] {
+  const owner: (SpanInput | null)[] = new Array(content.length).fill(null)
+  const valid = spans.filter(
+    s => s.end > s.start && s.start >= 0 && s.end <= content.length
+  )
+  for (const s of valid) {
+    for (let i = s.start; i < s.end; i++) {
+      const cur = owner[i]
+      if (!cur || rank(s.severity) > rank(cur.severity)) owner[i] = s
+    }
+  }
+
+  const segs: Segment[] = []
+  let i = 0
+  while (i < content.length) {
+    const o = owner[i]
+    let j = i + 1
+    while (j < content.length && owner[j] === o) j++
+    segs.push({
+      text: content.slice(i, j),
+      start: i,
+      end: j,
+      annId: o?.id ?? null,
+      severity: o?.severity ?? null,
+    })
+    i = j
+  }
+  return segs
+}
+
+// ── Applying accepted rewrites ────────────────────────────────────────────────
+
+export interface AcceptedEdit {
+  start: number
+  end: number
+  suggestion: string
+}
+
+// Apply accepted rewrites to `content`, producing the revised draft the student
+// carries into the next version. Splices right-to-left so each edit's offsets
+// stay valid while earlier text is untouched. Overlapping accepted edits are
+// resolved by keeping the earliest-starting one and dropping any that overlap it
+// (the review view should never offer overlapping accepts, but the splice must
+// not corrupt text if it does).
+export function applyAccepted(content: string, edits: AcceptedEdit[]): string {
+  const valid = edits
+    .filter(
+      e =>
+        Number.isInteger(e.start) &&
+        Number.isInteger(e.end) &&
+        e.start >= 0 &&
+        e.end <= content.length &&
+        e.end > e.start
+    )
+    .sort((a, b) => a.start - b.start)
+
+  const nonOverlap: AcceptedEdit[] = []
+  let lastEnd = -1
+  for (const e of valid) {
+    if (e.start >= lastEnd) {
+      nonOverlap.push(e)
+      lastEnd = e.end
+    }
+  }
+
+  let out = content
+  for (let i = nonOverlap.length - 1; i >= 0; i--) {
+    const e = nonOverlap[i]
+    out = out.slice(0, e.start) + e.suggestion + out.slice(e.end)
+  }
+  return out
+}

--- a/academy/web/src/lib/interlocutor.ts
+++ b/academy/web/src/lib/interlocutor.ts
@@ -177,6 +177,56 @@ Do not repeat the critique. They have read it. If they ask what you meant, answe
 
 Match their length. A one-line question gets a one-line answer. Do not open with a summary of what they just said.`
 
+// ── Annotation mode ─────────────────────────────────────────────────────────
+// The marked-up pass. Instead of one prose critique, the Interlocutor returns a
+// set of annotations, each fastened to a verbatim quote from the draft, so the
+// student sees each judgment on the sentence that earned it rather than a wall of
+// text they must map back onto their own work.
+//
+// This mode RELAXES the absolute constraint: an annotation may carry a concrete
+// rewrite in `suggestion`. The constraint's purpose (that the student earns the
+// prose) is preserved differently here: every suggestion ships with a `comment`
+// that names the flaw and why the rewrite answers it, and the student accepts or
+// rejects each one deliberately. The paired diagnosis is what keeps a rewrite
+// teaching rather than merely fixing.
+
+export const SEVERITY_LEVELS = ['critical', 'major', 'minor', 'note', 'strength'] as const
+export type Severity = (typeof SEVERITY_LEVELS)[number]
+
+// One marked-up span as the model returns it. Offsets are computed server-side
+// from `quote`; the model is never asked to count characters.
+export interface AnnotationOut {
+  quote: string
+  dimension: RubricDimension
+  severity: Severity
+  comment: string
+  suggestion: string | null
+}
+
+export const ANNOTATION_APPENDIX = `
+
+### This invocation: marked-up annotations
+
+You are marking up the draft, not writing a prose critique. Everything above still governs, with two changes to how you deliver it and one change to the absolute constraint.
+
+**Output.** Return a short summary and a set of annotations. The summary is one or two sentences naming the single most serious problem, with its rubric dimension: the lead you would open a critique with, and nothing more. No preamble, no recap of the draft. Each annotation fastens a judgment to a specific place in the text.
+
+For every annotation:
+- **quote**: copy the exact span of the student's text you are judging, verbatim, character for character, with its original punctuation. Do not paraphrase, normalize, or add or drop words. The quote is how the annotation is located in the draft, so a quote that is not a substring of the draft cannot be placed. Keep it as short as carries the point: usually a phrase or a sentence, rarely more than two.
+- **dimension**: the rubric dimension at stake (thesis, validity, soundness, charity, economy, fidelity).
+- **severity**: what it costs the argument.
+  - critical: the piece fails here (no thesis, an invalid core inference, a false load-bearing premise, a misattributed source).
+  - major: a real weakness a serious reader would hold against the argument.
+  - minor: a lapse worth fixing that does not threaten the argument.
+  - note: an observation or a question, not a fault.
+  - strength: something working well enough to name and keep. Use sparingly, only when true.
+- **comment**: the diagnosis. Name what the span does and fails to do, and ask the question that locates the fix. This is the teaching, and it is required on every annotation, including those that carry a suggestion.
+- **suggestion**: optional (see below); null when you are not offering a rewrite.
+
+**The relaxed constraint.** You may now offer a concrete rewrite in **suggestion** when a fix is better shown than only described. A suggestion is a proposed replacement for exactly the quoted span, in the student's own register, which the student will accept or reject. Two rules bind it: a suggestion never appears without a comment that explains the flaw and why the rewrite answers it (a rewrite the student cannot reason about is not teaching); and you suggest only where a rewrite genuinely helps, not on every annotation. Leave suggestion null for a pure diagnosis, for a strength, and wherever the student learns more by finding the words themselves. Never offer a suggestion that only restates the quote.
+
+Order annotations by severity, gravest first, not by reading order. Do not mark everything: a page dense with marks teaches nothing. Judge proportionally.`
+
 export interface WritingProfileRow {
   recurring_failures: {
     dimension?: string

--- a/academy/web/src/scripts/annotations-smoke.ts
+++ b/academy/web/src/scripts/annotations-smoke.ts
@@ -1,0 +1,122 @@
+// Offline unit test for src/lib/annotations.ts. No database, no model, no env.
+// Run:  npx tsx src/scripts/annotations-smoke.ts
+//
+// Covers the three things that would silently corrupt the marked-up view:
+// locating a quote (exact / whitespace-normalized / fuzzy / not-found), flatten-
+// ing overlapping spans into render segments, and splicing accepted rewrites
+// without drifting later offsets.
+
+import assert from 'node:assert'
+import { locate, buildSegments, applyAccepted, type SpanInput } from '../lib/annotations'
+
+let passed = 0
+function check(name: string, fn: () => void) {
+  fn()
+  passed++
+  console.log(`  ok  ${name}`)
+}
+
+const DRAFT =
+  'The thesis is that virtue suffices for happiness. ' + // 0..49
+  'Everyone agrees with this claim.\n\n' +               // 50..83 (\n\n at 82,83)
+  'It follows,   obviously,   that we need nothing else.' // wide gaps for ws test
+
+// ── locate ───────────────────────────────────────────────────────────────────
+
+check('locate: exact substring', () => {
+  const span = locate(DRAFT, 'virtue suffices for happiness')
+  assert.ok(span, 'expected a hit')
+  assert.strictEqual(DRAFT.slice(span!.start, span!.end), 'virtue suffices for happiness')
+})
+
+check('locate: whitespace-normalized (collapsed multi-space)', () => {
+  // The quote uses single spaces; the draft has runs of spaces. Must still map
+  // back to the real offsets that cover the original wide-gap text.
+  const span = locate(DRAFT, 'It follows, obviously, that we need nothing else.')
+  assert.ok(span, 'expected a normalized hit')
+  const got = DRAFT.slice(span!.start, span!.end)
+  assert.ok(got.startsWith('It follows,'), `got: ${JSON.stringify(got)}`)
+  assert.ok(got.endsWith('nothing else.'), `got: ${JSON.stringify(got)}`)
+})
+
+check('locate: whitespace-normalized across a newline', () => {
+  const span = locate(DRAFT, 'this claim. It follows')
+  assert.ok(span, 'expected a hit across the paragraph break')
+  const got = DRAFT.slice(span!.start, span!.end)
+  assert.ok(got.startsWith('this claim.'))
+  assert.ok(got.endsWith('It follows'))
+})
+
+check('locate: fuzzy anchor when the tail was altered', () => {
+  // Model quoted the span but mangled the end; the 40-char head still anchors.
+  const span = locate(DRAFT, 'The thesis is that virtue suffices for happiness FOREVER AND EVER')
+  assert.ok(span, 'expected a fuzzy hit')
+  assert.strictEqual(span!.start, 0)
+})
+
+check('locate: unfindable quote returns null', () => {
+  assert.strictEqual(locate(DRAFT, 'a sentence that is nowhere in the draft at all'), null)
+})
+
+check('locate: empty quote returns null', () => {
+  assert.strictEqual(locate(DRAFT, '   '), null)
+})
+
+// ── buildSegments ──────────────────────────────────────────────────────────────
+
+check('buildSegments: segments reconstruct the content exactly', () => {
+  const spans: SpanInput[] = [{ id: 'a', start: 4, end: 10, severity: 'major' }]
+  const segs = buildSegments(DRAFT, spans)
+  assert.strictEqual(segs.map(s => s.text).join(''), DRAFT)
+})
+
+check('buildSegments: overlap resolved by severity, higher wins', () => {
+  const content = 'ABCDEFGHIJ'
+  // minor covers 0..6, critical covers 3..8 — the overlap 3..6 must go critical.
+  const spans: SpanInput[] = [
+    { id: 'minor', start: 0, end: 6, severity: 'minor' },
+    { id: 'crit', start: 3, end: 8, severity: 'critical' },
+  ]
+  const segs = buildSegments(content, spans)
+  assert.strictEqual(segs.map(s => s.text).join(''), content, 'reconstruct')
+  const at = (i: number) => segs.find(s => i >= s.start && i < s.end)!
+  assert.strictEqual(at(0).annId, 'minor')
+  assert.strictEqual(at(4).annId, 'crit', 'overlap should belong to critical')
+  assert.strictEqual(at(7).annId, 'crit')
+  assert.strictEqual(at(9).annId, null, 'uncovered tail is plain')
+})
+
+// ── applyAccepted ──────────────────────────────────────────────────────────────
+
+check('applyAccepted: multi-accept keeps offsets valid (right-to-left)', () => {
+  const content = 'one two three'
+  // Replace 'one' (0..3) and 'three' (8..13) at once. If splicing left-to-right
+  // naively, the second offset would drift after the first replacement changes
+  // the length. Right-to-left keeps both correct.
+  const out = applyAccepted(content, [
+    { start: 0, end: 3, suggestion: 'ONE-LONGER' },
+    { start: 8, end: 13, suggestion: 'THREE' },
+  ])
+  assert.strictEqual(out, 'ONE-LONGER two THREE')
+})
+
+check('applyAccepted: overlapping accepts drop the later one', () => {
+  const content = 'ABCDEFGHIJ'
+  const out = applyAccepted(content, [
+    { start: 0, end: 6, suggestion: 'X' },
+    { start: 3, end: 8, suggestion: 'Y' }, // overlaps the first; dropped
+  ])
+  assert.strictEqual(out, 'XGHIJ')
+})
+
+check('applyAccepted: out-of-range edits are ignored', () => {
+  const content = 'short'
+  const out = applyAccepted(content, [
+    { start: 2, end: 99, suggestion: 'nope' },
+    { start: -1, end: 2, suggestion: 'nope' },
+    { start: 0, end: 2, suggestion: 'GO' },
+  ])
+  assert.strictEqual(out, 'GOort')
+})
+
+console.log(`\nannotations-smoke: ${passed} checks passed`)


### PR DESCRIPTION
Replace the composer's one-shot prose critique with inline, marked-up feedback and a draft-versioning loop.

- Migration 005: writing_pieces, piece_drafts (immutable snapshots), draft_annotations (offset-anchored), with RLS mirroring 004.
- Annotation mode in lib/interlocutor.ts: structured annotations anchored to verbatim quotes, severity levels, and a relaxed never-write rule that permits a concrete rewrite only when paired with a diagnosis.
- lib/annotations.ts: pure locate() (exact/normalized/fuzzy), overlap- resolved render segments, and right-to-left applyAccepted(). 11 unit checks in scripts/annotations-smoke.ts.
- /api/interlocutor/annotate: snapshots a version, locates offsets server- side (never trusting the model to count), persists annotations, and still writes one critique_history row per pass so the profile derivation is unchanged.
- MarkedUpDraft + DraftHistory components; composer reworked into the write -> markup -> accept/revise -> next-draft loop.