### PR TITLE
feat: Interlocutor Studio — marked-up feedback, draft iteration, guided stage flow

### DIFF
--- a/academy/web/src/app/api/interlocutor/annotate/route.ts
+++ b/academy/web/src/app/api/interlocutor/annotate/route.ts
@@ -6,6 +6,9 @@ import {
   ANNOTATION_APPENDIX,
   RUBRIC_DIMENSIONS,
   SEVERITY_LEVELS,
+  DEFAULT_STAGE,
+  isStage,
+  buildStageAppendix,
   buildProfileBlock,
   type WritingProfileRow,
   type AnnotationOut,
@@ -115,6 +118,10 @@ export async function POST(req: NextRequest) {
   const title =
     typeof body.title === 'string' && body.title.trim() ? body.title.trim().slice(0, 200) : null
 
+  // The guided-flow stage, validated. Drives which rubric dimensions the coach
+  // weights and whether it offers rewrites at all.
+  const stage = isStage(body.stage) ? body.stage : DEFAULT_STAGE
+
   // ── Resolve the piece: reuse an owned one, or start a new one ────────────────
   let pieceId: string
   if (typeof body.pieceId === 'string' && body.pieceId) {
@@ -128,16 +135,16 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Piece not found' }, { status: 404 })
     }
     pieceId = (piece as { id: string }).id
-    // Keep the title and the updated_at current.
+    // Keep the title, stage, and updated_at current.
     await supabase
       .from('writing_pieces')
-      .update({ title, updated_at: new Date().toISOString() })
+      .update({ title, stage, updated_at: new Date().toISOString() })
       .eq('id', pieceId)
       .eq('user_id', user.id)
   } else {
     const { data: created, error } = await supabase
       .from('writing_pieces')
-      .insert({ user_id: user.id, title, stage: body.stage || 'draft' })
+      .insert({ user_id: user.id, title, stage })
       .select('id')
       .single()
     if (error || !created) {
@@ -160,7 +167,10 @@ export async function POST(req: NextRequest) {
     console.warn('[interlocutor/annotate] profile read failed:', e)
   }
 
-  const system = [INTERLOCUTOR_SYSTEM + ANNOTATION_APPENDIX, buildProfileBlock(profile)].join('\n\n')
+  const system = [
+    INTERLOCUTOR_SYSTEM + ANNOTATION_APPENDIX + buildStageAppendix(stage),
+    buildProfileBlock(profile),
+  ].join('\n\n')
 
   const userContent = [
     title ? `PIECE: ${title}` : null,

--- a/academy/web/src/app/dashboard/composer/page.tsx
+++ b/academy/web/src/app/dashboard/composer/page.tsx
@@ -18,7 +18,9 @@ import { supabase } from '@/lib/supabase';
 import { InterlocutorChat, MIN_CRITIQUE_CHARS as MIN_CHARS } from '@/components/InterlocutorPanel';
 import { MarkedUpDraft, type Annotation } from '@/components/MarkedUpDraft';
 import { DraftHistory, type DraftSummary } from '@/components/DraftHistory';
+import { StageStepper } from '@/components/StageStepper';
 import { applyAccepted, type AcceptedEdit } from '@/lib/annotations';
+import { DEFAULT_STAGE, isStage, type Stage } from '@/lib/interlocutor';
 
 const DRAFT_KEY = 'interlocutor-draft';
 const TITLE_KEY = 'interlocutor-draft-title';
@@ -41,6 +43,7 @@ export default function ComposerPage() {
   const [title, setTitle] = useState('');
   const [text, setText] = useState('');
   const [pieceId, setPieceId] = useState<string | null>(null);
+  const [stage, setStage] = useState<Stage>(DEFAULT_STAGE);
 
   const [view, setView] = useState<'editor' | 'review'>('editor');
   const [review, setReview] = useState<ReviewData | null>(null);
@@ -100,6 +103,13 @@ export default function ComposerPage() {
       } catch {}
       if (pid) {
         setPieceId(pid);
+        const { data: piece } = await supabase
+          .from('writing_pieces')
+          .select('stage')
+          .eq('id', pid)
+          .maybeSingle();
+        const st = (piece as { stage?: string } | null)?.stage;
+        if (isStage(st)) setStage(st);
         await loadHistory(pid);
       }
       setLoaded(true);
@@ -134,6 +144,7 @@ export default function ComposerPage() {
           pieceId: pieceId || undefined,
           title: title.trim() || undefined,
           draftContent: text,
+          stage,
         }),
       });
       const data: unknown = await res.json();
@@ -244,11 +255,25 @@ export default function ComposerPage() {
     setView('review');
   };
 
+  // Set the guided-flow stage. Non-blocking; persists to the piece when one
+  // exists, otherwise rides along on the next submit.
+  const changeStage = async (s: Stage) => {
+    setStage(s);
+    if (pieceId) {
+      const { error: upErr } = await supabase
+        .from('writing_pieces')
+        .update({ stage: s })
+        .eq('id', pieceId);
+      if (upErr) setNotice('The stage change did not save, but it applies here.');
+    }
+  };
+
   const newPiece = () => {
     setPieceId(null);
     setReview(null);
     setLiveDraftId(null);
     setHistory([]);
+    setStage(DEFAULT_STAGE);
     setView('editor');
     handleTitleChange('');
     handleTextChange('');
@@ -293,6 +318,7 @@ export default function ComposerPage() {
         <div className="min-w-0">
           {view === 'editor' ? (
             <>
+              <StageStepper stage={stage} onChange={changeStage} />
               <input
                 className="w-full bg-transparent border-b border-academy-border focus:border-academy-gold focus:outline-none font-serif text-academy-text text-2xl pb-2 mb-6 placeholder-academy-muted"
                 placeholder="Untitled"

--- a/academy/web/src/app/dashboard/composer/page.tsx
+++ b/academy/web/src/app/dashboard/composer/page.tsx
@@ -16,7 +16,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabase';
 import { InterlocutorChat, MIN_CRITIQUE_CHARS as MIN_CHARS } from '@/components/InterlocutorPanel';
-import { MarkedUpDraft, type Annotation } from '@/components/MarkedUpDraft';
+import { MarkedUpDraft, CommentList, type Annotation } from '@/components/MarkedUpDraft';
 import { DraftHistory, type DraftSummary } from '@/components/DraftHistory';
 import { StageStepper } from '@/components/StageStepper';
 import { applyAccepted, type AcceptedEdit } from '@/lib/annotations';
@@ -291,7 +291,7 @@ export default function ComposerPage() {
   const reviewReadOnly = review ? review.draftId !== liveDraftId : true;
 
   return (
-    <div className="max-w-6xl">
+    <div className="max-w-[1600px]">
       <header className="mb-8 flex items-start justify-between gap-4">
         <div>
           <p className="font-mono text-academy-gold text-xs uppercase tracking-[0.3em] mb-2">
@@ -319,40 +319,63 @@ export default function ComposerPage() {
           {view === 'editor' ? (
             <>
               <StageStepper stage={stage} onChange={changeStage} />
-              <input
-                className="w-full bg-transparent border-b border-academy-border focus:border-academy-gold focus:outline-none font-serif text-academy-text text-2xl pb-2 mb-6 placeholder-academy-muted"
-                placeholder="Untitled"
-                value={title}
-                onChange={e => handleTitleChange(e.target.value)}
-              />
+              <div
+                className={
+                  review ? 'grid grid-cols-1 lg:grid-cols-[1fr_400px] gap-10 items-start' : ''
+                }
+              >
+                <div className="min-w-0">
+                  <input
+                    className="w-full bg-transparent border-b border-academy-border focus:border-academy-gold focus:outline-none font-serif text-academy-text text-2xl pb-2 mb-6 placeholder-academy-muted"
+                    placeholder="Untitled"
+                    value={title}
+                    onChange={e => handleTitleChange(e.target.value)}
+                  />
 
-              <textarea
-                ref={editorRef}
-                className="w-full min-h-[55vh] bg-navy border border-academy-border rounded-lg px-5 py-4 font-serif text-academy-text text-[15px] leading-[1.8] placeholder-academy-muted focus:border-academy-gold focus:outline-none resize-y"
-                placeholder="Begin."
-                value={text}
-                onChange={e => handleTextChange(e.target.value)}
-              />
+                  <textarea
+                    ref={editorRef}
+                    className="w-full min-h-[55vh] bg-navy border border-academy-border rounded-lg px-5 py-4 font-serif text-academy-text text-[15px] leading-[1.8] placeholder-academy-muted focus:border-academy-gold focus:outline-none resize-y"
+                    placeholder="Begin."
+                    value={text}
+                    onChange={e => handleTextChange(e.target.value)}
+                  />
 
-              <div className="flex items-center justify-between mt-2 text-xs text-academy-muted font-mono">
-                <span>{words} word{words === 1 ? '' : 's'}</span>
+                  <div className="flex items-center justify-between mt-2 text-xs text-academy-muted font-mono">
+                    <span>{words} word{words === 1 ? '' : 's'}</span>
+                    {review && (
+                      <button onClick={() => setView('review')} className="hover:text-academy-text">
+                        ← back to the markup
+                      </button>
+                    )}
+                  </div>
+
+                  <div className="mt-8 border-t border-academy-gold/20 pt-6 flex flex-wrap items-center gap-4">
+                    <button
+                      onClick={invoke}
+                      disabled={!canSubmit}
+                      className="bg-academy-gold text-academy-bg font-semibold rounded-lg px-6 py-3 text-sm hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                      {working ? 'Reading…' : review ? 'Submit the next draft' : 'Submit for markup'}
+                    </button>
+                    {submission.length > 0 && submission.length < MIN_CHARS && (
+                      <span className="text-academy-muted text-xs">Too little to judge.</span>
+                    )}
+                  </div>
+                </div>
+
+                {/* While revising, keep the markup's comments in view beside the editor. */}
                 {review && (
-                  <button onClick={() => setView('review')} className="hover:text-academy-text">
-                    ← back to the markup
-                  </button>
-                )}
-              </div>
-
-              <div className="mt-8 border-t border-academy-gold/20 pt-6 flex flex-wrap items-center gap-4">
-                <button
-                  onClick={invoke}
-                  disabled={!canSubmit}
-                  className="bg-academy-gold text-academy-bg font-semibold rounded-lg px-6 py-3 text-sm hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
-                >
-                  {working ? 'Reading…' : review ? 'Submit the next draft' : 'Submit for markup'}
-                </button>
-                {submission.length > 0 && submission.length < MIN_CHARS && (
-                  <span className="text-academy-muted text-xs">Too little to judge.</span>
+                  <aside className="lg:sticky lg:top-4">
+                    <p className="font-mono text-academy-gold text-[10px] uppercase tracking-widest mb-3">
+                      Comments · draft v{review.version}
+                    </p>
+                    <CommentList
+                      annotations={review.annotations}
+                      generalNotes={review.generalNotes}
+                      summary={review.summary || undefined}
+                      readOnly
+                    />
+                  </aside>
                 )}
               </div>
             </>

--- a/academy/web/src/components/MarkedUpDraft.tsx
+++ b/academy/web/src/components/MarkedUpDraft.tsx
@@ -6,8 +6,8 @@
 // snapshot, and revision happens by accepting suggestions or editing back in the
 // composer, which produces a new version.
 //
-// Presentational: it owns only which annotation is highlighted. Accept / dismiss
-// and the working-copy splice belong to the page, so one place owns the draft.
+// The comment cards live in CommentList, exported so the editor view can show the
+// same comments beside the textarea while the student revises.
 
 import { useState } from 'react';
 import { buildSegments, type SpanInput } from '@/lib/annotations';
@@ -46,6 +46,180 @@ function SeverityDot({ severity }: { severity: string }) {
   );
 }
 
+// The Interlocutor's summary lead: the single most serious problem.
+export function SummaryLead({ summary }: { summary: string }) {
+  return (
+    <p className="text-academy-muted text-[15px] leading-relaxed">
+      <span className="font-mono text-academy-gold text-[10px] uppercase tracking-widest block mb-1.5">
+        The central problem
+      </span>
+      {summary}
+    </p>
+  );
+}
+
+// One comment card. Located and general (unlocated) annotations both render here;
+// only located ones also become an inline highlight in the reviewed text.
+function AnnotationCard({
+  a,
+  active,
+  readOnly,
+  onFocus,
+  onAccept,
+  onDismiss,
+}: {
+  a: Annotation;
+  active: boolean;
+  readOnly: boolean;
+  onFocus?: (id: string) => void;
+  onAccept?: (a: Annotation) => void;
+  onDismiss?: (a: Annotation) => void;
+}) {
+  const sev = sevOf(a.severity);
+  const dealt = a.status !== 'open';
+  const clickable = a.start_offset !== null && !!onFocus;
+  return (
+    <div
+      id={`card-${a.id}`}
+      onClick={() => clickable && onFocus?.(a.id)}
+      className="rounded-lg border p-3.5 transition-colors"
+      style={{
+        borderColor: active ? sev.color : 'rgba(30,50,88,0.9)',
+        background: active ? `${sev.color}12` : 'rgba(15,30,56,0.5)',
+        cursor: clickable ? 'pointer' : 'default',
+        opacity: dealt ? 0.55 : 1,
+      }}
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <SeverityDot severity={a.severity} />
+        <span className="font-mono text-[10px] uppercase tracking-wider" style={{ color: sev.color }}>
+          {sev.label}
+        </span>
+        <DimensionChips dimensions={[a.dimension]} />
+        {a.start_offset === null && (
+          <span className="font-mono text-[9px] uppercase tracking-wider text-academy-muted ml-auto">
+            general
+          </span>
+        )}
+        {dealt && (
+          <span className="font-mono text-[9px] uppercase tracking-wider text-academy-muted ml-auto">
+            {a.status}
+          </span>
+        )}
+      </div>
+
+      {/* Show the quoted span for general notes (no highlight to point at) and,
+          in the editor view, for located ones too, so the comment stands alone. */}
+      {a.quote && (
+        <p className="font-serif italic text-academy-muted text-[13px] mb-1.5 leading-snug">
+          &ldquo;{a.quote.slice(0, 160)}
+          {a.quote.length > 160 ? '…' : ''}&rdquo;
+        </p>
+      )}
+
+      <p className="font-serif text-academy-text text-[14px] leading-relaxed">{a.comment}</p>
+
+      {a.suggestion && (
+        <div className="mt-2.5 pt-2.5 border-t border-academy-border">
+          <span className="font-mono text-[9px] uppercase tracking-wider text-academy-muted block mb-1">
+            Suggested rewrite
+          </span>
+          <p className="font-serif text-academy-gold text-[14px] leading-relaxed">{a.suggestion}</p>
+          {!readOnly && a.status === 'open' && (
+            <div className="flex gap-2 mt-2.5">
+              <button
+                onClick={e => {
+                  e.stopPropagation();
+                  onAccept?.(a);
+                }}
+                className="bg-academy-gold text-academy-bg font-semibold rounded px-3 py-1.5 text-xs hover:opacity-90"
+              >
+                Accept
+              </button>
+              <button
+                onClick={e => {
+                  e.stopPropagation();
+                  onDismiss?.(a);
+                }}
+                className="border border-academy-border text-academy-muted hover:text-academy-text rounded px-3 py-1.5 text-xs"
+              >
+                Dismiss
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {!a.suggestion && !readOnly && a.status === 'open' && (
+        <button
+          onClick={e => {
+            e.stopPropagation();
+            onDismiss?.(a);
+          }}
+          className="mt-2 font-mono text-[10px] uppercase tracking-wider text-academy-muted hover:text-academy-text"
+        >
+          Mark addressed
+        </button>
+      )}
+    </div>
+  );
+}
+
+// The comment column. Renders located and general annotations as cards, gravest
+// first. Used inside MarkedUpDraft (with span linking) and beside the editor
+// textarea (read-only reference while revising).
+export function CommentList({
+  annotations,
+  generalNotes = [],
+  summary,
+  readOnly = false,
+  onAccept,
+  onDismiss,
+  activeId = null,
+  onCardFocus,
+}: {
+  annotations: Annotation[];
+  generalNotes?: Annotation[];
+  summary?: string;
+  readOnly?: boolean;
+  onAccept?: (a: Annotation) => void;
+  onDismiss?: (a: Annotation) => void;
+  activeId?: string | null;
+  onCardFocus?: (id: string) => void;
+}) {
+  const cards = [...annotations, ...generalNotes].sort(
+    (a, b) =>
+      sevOf(b.severity).rank - sevOf(a.severity).rank ||
+      (a.start_offset ?? 1e9) - (b.start_offset ?? 1e9)
+  );
+
+  return (
+    <div className="space-y-3">
+      {summary && (
+        <div className="rounded-lg border border-academy-gold/25 bg-academy-surface/40 p-3.5">
+          <SummaryLead summary={summary} />
+        </div>
+      )}
+      {cards.length === 0 && (
+        <p className="font-serif italic text-academy-muted text-sm">
+          Nothing marked. Either the draft holds, or there was too little to judge.
+        </p>
+      )}
+      {cards.map(a => (
+        <AnnotationCard
+          key={a.id}
+          a={a}
+          active={a.id === activeId}
+          readOnly={readOnly}
+          onFocus={onCardFocus}
+          onAccept={onAccept}
+          onDismiss={onDismiss}
+        />
+      ))}
+    </div>
+  );
+}
+
 export function MarkedUpDraft({
   content,
   annotations,
@@ -66,8 +240,7 @@ export function MarkedUpDraft({
   const [activeId, setActiveId] = useState<string | null>(null);
 
   // Only open, located annotations get an inline highlight. Accepted or dismissed
-  // ones drop out of the text (the student has dealt with them) but remain in the
-  // margin as a record.
+  // ones drop out of the text but remain in the margin as a record.
   const inline = annotations.filter(
     a => a.start_offset !== null && a.end_offset !== null && a.status === 'open'
   );
@@ -79,14 +252,7 @@ export function MarkedUpDraft({
   }));
   const segments = buildSegments(content, spans);
 
-  // Margin order: gravest first, then document position.
-  const ordered = [...annotations].sort(
-    (a, b) =>
-      sevOf(b.severity).rank - sevOf(a.severity).rank ||
-      (a.start_offset ?? 1e9) - (b.start_offset ?? 1e9)
-  );
-
-  const focus = (id: string) => {
+  const focusCard = (id: string) => {
     setActiveId(id);
     const el = document.getElementById(`card-${id}`);
     if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -98,16 +264,13 @@ export function MarkedUpDraft({
   };
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-[1fr_360px] gap-8 items-start">
+    <div className="grid grid-cols-1 lg:grid-cols-[1fr_400px] gap-10 items-start">
       {/* ── The marked-up text ─────────────────────────────────────────────── */}
       <article className="font-serif text-academy-text text-[16px] leading-[1.9] whitespace-pre-wrap">
         {summary && (
-          <p className="mb-6 pb-5 border-b border-academy-gold/25 text-academy-muted text-[15px] leading-relaxed not-italic">
-            <span className="font-mono text-academy-gold text-[10px] uppercase tracking-widest block mb-1.5">
-              The central problem
-            </span>
-            {summary}
-          </p>
+          <div className="mb-6 pb-5 border-b border-academy-gold/25">
+            <SummaryLead summary={summary} />
+          </div>
         )}
         {segments.map((seg, i) => {
           if (!seg.annId) return <span key={i}>{seg.text}</span>;
@@ -117,7 +280,7 @@ export function MarkedUpDraft({
             <span
               key={i}
               id={`hl-${seg.annId}`}
-              onClick={() => focus(seg.annId as string)}
+              onClick={() => focusCard(seg.annId as string)}
               className="cursor-pointer rounded-sm transition-colors"
               style={{
                 borderBottom: `2px solid ${sev.color}`,
@@ -132,110 +295,16 @@ export function MarkedUpDraft({
       </article>
 
       {/* ── The margin ─────────────────────────────────────────────────────── */}
-      <aside className="lg:sticky lg:top-4 space-y-3">
-        {ordered.length === 0 && generalNotes.length === 0 && (
-          <p className="font-serif italic text-academy-muted text-sm">
-            Nothing marked. Either the draft holds, or there was too little to judge.
-          </p>
-        )}
-
-        {ordered.map(a => {
-          const sev = sevOf(a.severity);
-          const isActive = a.id === activeId;
-          const dealt = a.status !== 'open';
-          return (
-            <div
-              key={a.id}
-              id={`card-${a.id}`}
-              onClick={() => a.start_offset !== null && focusSpan(a.id)}
-              className="rounded-lg border p-3.5 transition-colors"
-              style={{
-                borderColor: isActive ? sev.color : 'rgba(30,50,88,0.9)',
-                background: isActive ? `${sev.color}12` : 'rgba(15,30,56,0.5)',
-                cursor: a.start_offset !== null ? 'pointer' : 'default',
-                opacity: dealt ? 0.55 : 1,
-              }}
-            >
-              <div className="flex items-center gap-2 mb-2">
-                <SeverityDot severity={a.severity} />
-                <span
-                  className="font-mono text-[10px] uppercase tracking-wider"
-                  style={{ color: sev.color }}
-                >
-                  {sev.label}
-                </span>
-                <DimensionChips dimensions={[a.dimension]} />
-                {a.start_offset === null && (
-                  <span className="font-mono text-[9px] uppercase tracking-wider text-academy-muted ml-auto">
-                    general
-                  </span>
-                )}
-                {dealt && (
-                  <span className="font-mono text-[9px] uppercase tracking-wider text-academy-muted ml-auto">
-                    {a.status}
-                  </span>
-                )}
-              </div>
-
-              {a.start_offset === null && a.quote && (
-                <p className="font-serif italic text-academy-muted text-[13px] mb-1.5 leading-snug">
-                  &ldquo;{a.quote.slice(0, 140)}
-                  {a.quote.length > 140 ? '…' : ''}&rdquo;
-                </p>
-              )}
-
-              <p className="font-serif text-academy-text text-[14px] leading-relaxed">
-                {a.comment}
-              </p>
-
-              {a.suggestion && (
-                <div className="mt-2.5 pt-2.5 border-t border-academy-border">
-                  <span className="font-mono text-[9px] uppercase tracking-wider text-academy-muted block mb-1">
-                    Suggested rewrite
-                  </span>
-                  <p className="font-serif text-academy-gold text-[14px] leading-relaxed">
-                    {a.suggestion}
-                  </p>
-                  {!readOnly && a.status === 'open' && (
-                    <div className="flex gap-2 mt-2.5">
-                      <button
-                        onClick={e => {
-                          e.stopPropagation();
-                          onAccept?.(a);
-                        }}
-                        className="bg-academy-gold text-academy-bg font-semibold rounded px-3 py-1.5 text-xs hover:opacity-90"
-                      >
-                        Accept
-                      </button>
-                      <button
-                        onClick={e => {
-                          e.stopPropagation();
-                          onDismiss?.(a);
-                        }}
-                        className="border border-academy-border text-academy-muted hover:text-academy-text rounded px-3 py-1.5 text-xs"
-                      >
-                        Dismiss
-                      </button>
-                    </div>
-                  )}
-                </div>
-              )}
-
-              {/* A diagnosis with no rewrite can still be dismissed once addressed. */}
-              {!a.suggestion && !readOnly && a.status === 'open' && (
-                <button
-                  onClick={e => {
-                    e.stopPropagation();
-                    onDismiss?.(a);
-                  }}
-                  className="mt-2 font-mono text-[10px] uppercase tracking-wider text-academy-muted hover:text-academy-text"
-                >
-                  Mark addressed
-                </button>
-              )}
-            </div>
-          );
-        })}
+      <aside className="lg:sticky lg:top-4">
+        <CommentList
+          annotations={annotations}
+          generalNotes={generalNotes}
+          readOnly={readOnly}
+          onAccept={onAccept}
+          onDismiss={onDismiss}
+          activeId={activeId}
+          onCardFocus={focusSpan}
+        />
       </aside>
     </div>
   );

--- a/academy/web/src/components/StageStepper.tsx
+++ b/academy/web/src/components/StageStepper.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+// The guided-flow stepper. Five stages, non-blocking: clicking one sets the
+// piece's stage, which tunes what the Interlocutor weights and whether it offers
+// rewrites. It never gates a submission — a student can draft first and name the
+// thesis after, or jump straight to polish. Below the rail sits the current
+// stage's intent and a short checklist: guidance, not requirements.
+
+import { STAGES, STAGE_CHECKLIST, type Stage } from '@/lib/interlocutor';
+
+export function StageStepper({
+  stage,
+  onChange,
+}: {
+  stage: Stage;
+  onChange: (s: Stage) => void;
+}) {
+  const currentIdx = STAGES.findIndex(s => s.id === stage);
+  const active = STAGES[currentIdx] ?? STAGES[0];
+
+  return (
+    <div className="mb-6">
+      <div className="flex items-center gap-1.5 mb-3">
+        {STAGES.map((s, i) => {
+          const isCurrent = s.id === stage;
+          const isPast = i < currentIdx;
+          return (
+            <div key={s.id} className="flex items-center gap-1.5 flex-1 min-w-0">
+              <button
+                onClick={() => onChange(s.id)}
+                className="flex items-center gap-2 min-w-0 group"
+                title={s.blurb}
+              >
+                <span
+                  className={`flex-shrink-0 w-5 h-5 rounded-full flex items-center justify-center font-mono text-[10px] border transition-colors ${
+                    isCurrent
+                      ? 'bg-academy-gold text-academy-bg border-academy-gold'
+                      : isPast
+                        ? 'border-academy-gold/60 text-academy-gold/80'
+                        : 'border-academy-border text-academy-muted group-hover:border-academy-gold/50'
+                  }`}
+                >
+                  {i + 1}
+                </span>
+                <span
+                  className={`font-mono text-[11px] uppercase tracking-wider truncate transition-colors ${
+                    isCurrent
+                      ? 'text-academy-gold'
+                      : 'text-academy-muted group-hover:text-academy-text'
+                  }`}
+                >
+                  {s.label}
+                </span>
+              </button>
+              {i < STAGES.length - 1 && (
+                <span
+                  className={`h-px flex-1 min-w-[8px] ${isPast ? 'bg-academy-gold/40' : 'bg-academy-border'}`}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="rounded-lg border border-academy-border bg-academy-surface/40 px-4 py-3">
+        <p className="font-serif italic text-academy-text text-sm mb-2">{active.blurb}</p>
+        <ul className="space-y-1">
+          {STAGE_CHECKLIST[active.id].map((c, i) => (
+            <li
+              key={i}
+              className="flex items-start gap-2 text-academy-muted text-[13px] leading-relaxed"
+            >
+              <span className="text-academy-gold mt-0.5" aria-hidden>
+                ·
+              </span>
+              <span>{c}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/academy/web/src/lib/interlocutor.ts
+++ b/academy/web/src/lib/interlocutor.ts
@@ -227,6 +227,85 @@ For every annotation:
 
 Order annotations by severity, gravest first, not by reading order. Do not mark everything: a page dense with marks teaches nothing. Judge proportionally.`
 
+// ── The guided stage flow ────────────────────────────────────────────────────
+// A piece moves through five stages. The flow is non-blocking: the student sets
+// the stage and may jump freely; it never gates a submission. Its only effect is
+// to tune what the Interlocutor weights, and whether it offers rewrites at all.
+//
+// This is also where the never-write pedagogy is re-honored by stage even though
+// the annotation mode relaxes it globally: at thesis and outline the coach offers
+// no rewrites (the claim and its sequence must be the student's own); by polish,
+// where the argument is settled, it offers them freely.
+
+export const STAGES = [
+  { id: 'thesis', label: 'Thesis', blurb: 'Find the one claim a reasonable person could deny.' },
+  { id: 'outline', label: 'Outline', blurb: 'Sequence the argument so each step earns the next.' },
+  { id: 'draft', label: 'Draft', blurb: 'Write it through, start to finish, without polishing.' },
+  { id: 'revise', label: 'Revise', blurb: 'Test validity, soundness, and the opposing case.' },
+  { id: 'polish', label: 'Polish', blurb: 'Cut, tighten, and sharpen every sentence.' },
+] as const
+
+export type Stage = (typeof STAGES)[number]['id']
+
+export const DEFAULT_STAGE: Stage = 'draft'
+
+export function isStage(s: unknown): s is Stage {
+  return typeof s === 'string' && STAGES.some(st => st.id === s)
+}
+
+// Short, actionable prompts shown beside the editor. Guidance, never a gate.
+export const STAGE_CHECKLIST: Record<Stage, string[]> = {
+  thesis: [
+    'State the thesis in a single sentence.',
+    'Confirm a reasonable person could deny it.',
+    'Cut any throat-clearing before the claim.',
+  ],
+  outline: [
+    'List each claim in the order it must be made.',
+    'For every step, name what it earns.',
+    'Mark the premise carrying the most weight.',
+  ],
+  draft: [
+    'Write to the end without stopping to polish.',
+    'Keep every paragraph advancing the one thesis.',
+    'State the opposing view at full strength.',
+  ],
+  revise: [
+    'Make each inference explicit; name missing premises.',
+    'Press the premise you assumed was obvious.',
+    'Strengthen the strongest objection, then answer it.',
+  ],
+  polish: [
+    'Delete any paragraph that loses nothing when cut.',
+    'Remove hedging that protects you, not the claim.',
+    'Read for rhythm; land each sentence on its turn.',
+  ],
+}
+
+// The per-stage instruction appended to the system prompt after ANNOTATION_APPENDIX,
+// so its stage-specific rewrite policy overrides the general permission above.
+export function buildStageAppendix(stage: string): string {
+  const s: Stage = isStage(stage) ? stage : DEFAULT_STAGE
+  const blocks: Record<Stage, string> = {
+    thesis: `### This piece is at the THESIS stage
+
+The student is trying to find a single claim a reasonable person could deny. Judge Thesis above everything: whether one exists, whether it is deniable, whether it is announced or buried rather than made. Economy and sentence craft are premature; mark them only where they obscure the claim. Override the general suggestion guidance: offer NO rewrites at this stage, leaving every suggestion null. The claim must be forged in the student's own words; a thesis handed over is the one thing that must not be.`,
+    outline: `### This piece is at the OUTLINE stage
+
+The student is sequencing the argument. Judge Thesis and the arc: whether each step earns the next, whether the load-bearing premise is identified, whether the order builds or merely lists. Do not mark sentence craft. Override the general suggestion guidance: offer NO rewrites at this stage, leaving every suggestion null; an outline is reasoning to be repaired, not prose to be replaced.`,
+    draft: `### This piece is at the DRAFT stage
+
+The student is writing the argument through. Judge the full rubric, but weight Thesis, Validity, and Charity over Economy: it is early to cut what is not yet fully built. Offer rewrites sparingly, only where a structural fix is genuinely clearer shown than described.`,
+    revise: `### This piece is at the REVISE stage
+
+The argument exists and the student is strengthening it. Weight Validity, Soundness, and Charity. Press the missing premises and the strongest objection. Offer rewrites where they teach a move the student can reuse, still not on every mark.`,
+    polish: `### This piece is at the POLISH stage
+
+The argument is settled and the student is sharpening the prose. Weight Economy and register: hedging, throat-clearing, restatement, adjectives doing an argument's work. This is where a concrete rewrite helps most, so offer suggestions freely wherever a tighter line is better shown than described. Do not reopen the thesis unless it has genuinely broken.`,
+  }
+  return `\n\n${blocks[s]}`
+}
+
 export interface WritingProfileRow {
   recurring_failures: {
     dimension?: string


### PR DESCRIPTION
Reworks the Interlocutor composer from a one-shot prose critique into a marked-up writing studio, per Kyle's feedback that the old feedback was too long and not specific enough.

## What changed
**Phase 1 — marked-up feedback + draft iteration**
- Submitting a draft snapshots it as an immutable version and returns annotations anchored to the sentences that earned them, colored by severity (critical/major/minor/note/strength).
- The never-write rule is relaxed: annotations may carry a concrete rewrite you Accept or Dismiss — but every suggestion ships with a diagnosis explaining why, so it still teaches. Accepting splices the rewrite into a working copy for the next version.
- A version rail shows each draft with its severity tally, so you can watch the argument get less red over time.

**Phase 2 — guided stage flow (non-blocking)**
- Thesis → Outline → Draft → Revise → Polish. The stage tunes what the coach weights and whether it offers rewrites at all: thesis/outline withhold rewrites (the claim and its sequence must be your own); polish offers them freely. Re-honors the never-write pedagogy by stage.

**Layout**
- Wider studio (max-w-[1600px]); the markup's comments stay visible beside the editor while revising; unlocated "general" notes now render as cards.

## Architecture notes
- New tables `writing_pieces`, `piece_drafts`, `draft_annotations` (migration `005_interlocutor_studio.sql`), RLS mirroring `004`. **The migration is already applied to prod DB `zhaarabzemhantyxxckq`.**
- Offsets are located server-side from the model's verbatim quotes (the model never counts characters); pure logic in `web/src/lib/annotations.ts` with 11 unit checks.
- Still writes one `critique_history` row per pass, so the nightly `writing_profile` derivation is unchanged.
- The prose-critique route and the Papers/Dissertation `AskInterlocutor` surfaces are untouched.

## Verification
- `tsc --noEmit` clean; `next build` passes.
- `npx tsx src/scripts/annotations-smoke.ts` — 11/11.
- Not yet exercised interactively end-to-end (needs a logged-in session + a live model call).

## Deferred
- Phase 3: exercises generated from the writing profile's recurring weaknesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)