### PR TITLE
feat: Perspectives essay page — The Notebook and the Tapes

### DIFF
--- a/academy/web/src/app/perspectives/[slug]/page.tsx
+++ b/academy/web/src/app/perspectives/[slug]/page.tsx
@@ -1,0 +1,171 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+
+import { allSlugs, getPerspective } from "@/content/perspectives";
+import Reveal from "@/components/perspectives/Reveal";
+import "../perspectives.css";
+
+export function generateStaticParams() {
+  return allSlugs().map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const p = getPerspective(slug);
+  if (!p) return {};
+  return {
+    title: `${p.title} | ${p.series} | Arete Academy`,
+    description: p.standfirst,
+    openGraph: { title: p.title, description: p.standfirst, type: "article" },
+  };
+}
+
+const ESSAY = [
+  "Socrates held that no one does wrong willingly. Not that wrongdoing is rare, and not that it is excusable, but that every action is aimed at something the agent takes to be good, so that when the aim is monstrous the failure lies in the taking. Vice is a defect of sight before it is a defect of will.",
+  "This is the easiest doctrine in the school to agree with and the hardest to hold for longer than a paragraph. It survives contact with the careless driver and the difficult colleague. It collapses the moment you meet someone whose error has a body count, because at that point the mind reaches for a simpler instrument, which is the villain.",
+  "What follows is built to make the doctrine difficult rather than comfortable. Two documents cover the same nine days of the same war. On the left, a father in east Tehran writes in the exercise book that came home in his nine year old daughter's school bag. On the right, the man who ordered the strike dictates his memoir into a recorder, in a room with no one in it who will contradict him.",
+  "Neither man believes he is doing wrong. One of them is right about that.",
+];
+
+const HOWTO = [
+  "Read across, not down. The pairing is the argument, and the dates are matched deliberately, so the entry that takes the father forty days of mourning is the entry in which the president grades his own performance on a tarmac at six in the morning.",
+  "Between the two columns, at the foot of each day, the canon reads both men at once. It is the only voice on this page that can see both.",
+];
+
+const STEPS = [
+  ["Write their account in the first person.", "Not a confession and not a satire. The version in which they are the reasonable party, the version they would recognize, containing the true grievances as well as the false ones."],
+  ["Find the assent.", "Somewhere in what you have written there is a moment where a false impression was accepted as fact. Mark it. It is almost never at the dramatic point. It is usually early, small, and phrased as something obvious."],
+  ["Name the good they were reaching for.", "Safety, standing, loyalty, the protection of someone. It will be a real good, aimed at badly. If you cannot find one you have not finished step one."],
+  ["Find the same move in your own week.", "This is the step people skip, and it is the only one that changes anything."],
+];
+
+export default async function PerspectivePage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const p = getPerspective(slug);
+  if (!p) notFound();
+
+  return (
+    <main className="pv">
+      <header className="pv-hero">
+        <span className="pv-seamline" aria-hidden="true" />
+        <p className="pv-eyebrow">
+          {p.series} <span aria-hidden="true">&middot;</span> Arete Academy
+        </p>
+        <h1>{p.title}</h1>
+        <p className="pv-standfirst">{p.standfirst}</p>
+      </header>
+
+      <section className="pv-essay">
+        <div className="pv-epigraph">
+          <q>{p.epigraph.rendering}</q>
+          <cite>
+            {p.epigraph.work} <span aria-hidden="true">/</span> {p.epigraph.text_ref}
+          </cite>
+        </div>
+        <div className="pv-essay-in">
+          {ESSAY.map((t, i) => (
+            <p key={i}>{t}</p>
+          ))}
+          <div className="pv-howto">
+            {HOWTO.map((t, i) => (
+              <p key={i}>{t}</p>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {p.entries.map((e, i) => (
+        <section className="pv-band" key={e.date} aria-labelledby={`pv-d${i}`}>
+          <div className="pv-band-head">
+            <span className="pv-rule" aria-hidden="true" />
+            <h2 id={`pv-d${i}`} className="pv-band-date">
+              {e.date}
+              <span className="pv-yr">{e.year}</span>
+            </h2>
+            <span className="pv-rule" aria-hidden="true" />
+          </div>
+
+          <div className="pv-cols">
+            <div className="pv-col pv-col-paper">
+              <p className="pv-col-tag">{p.left.label}</p>
+              {e.notebook.map((t, j) => (
+                <p className="pv-ink" key={j}>
+                  {t}
+                </p>
+              ))}
+            </div>
+            <div className="pv-col pv-col-tape">
+              <p className="pv-col-tag">{p.right.label}</p>
+              {e.tape.map((t, j) => (
+                <p className="pv-mono" key={j}>
+                  {t}
+                </p>
+              ))}
+            </div>
+          </div>
+
+          <Reveal className="pv-canon">
+            <p className="pv-canon-ref">
+              <span className="pv-dot" aria-hidden="true" />
+              {e.canon.work}
+              <span className="pv-sep">/</span>
+              {e.canon.text_ref}
+            </p>
+            <blockquote className="pv-canon-q">{e.canon.rendering}</blockquote>
+            {e.canon.note ? <p className="pv-canon-note">{e.canon.note}</p> : null}
+          </Reveal>
+        </section>
+      ))}
+
+      <section className="pv-close">
+        <div className="pv-close-in">
+          <h3>The exercise</h3>
+          <p>
+            Choose someone whose conduct you find indefensible. Not a stranger in the
+            news. Someone whose actions have cost you something.
+          </p>
+          <ol>
+            {STEPS.map(([head, body]) => (
+              <li key={head}>
+                <strong>{head}</strong> {body}
+              </li>
+            ))}
+          </ol>
+          <p className="pv-warn">
+            A caution, since this exercise is regularly misunderstood as a route to
+            forgiveness. It is not, and Marcus never claims it is. The father is
+            explicit in his last entry that he does not forgive and hopes the
+            responsible are made to look at what they did, by name, one child at a
+            time. Understanding the mechanism of another person&rsquo;s error tells you
+            what happened. It does not tell you what is owed. Those are separate
+            questions and the school keeps them separate.
+          </p>
+          <Link className="pv-cta" href="/courses/phil-706">
+            Study this in PHIL 706
+          </Link>
+        </div>
+      </section>
+
+      <footer className="pv-foot">
+        <div className="pv-foot-in">
+          <p>
+            Both documents are fiction. The father, the president, their families and
+            their staff are invented. The chronology of the war is drawn from the public
+            record of 2026. Canon renderings are close paraphrase from public domain
+            translations and carry the standard references so they can be read against
+            any edition.
+          </p>
+        </div>
+      </footer>
+    </main>
+  );
+}

--- a/academy/web/src/app/perspectives/layout.tsx
+++ b/academy/web/src/app/perspectives/layout.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from 'next';
+import { Fraunces, Newsreader, IBM_Plex_Mono, IBM_Plex_Sans } from 'next/font/google';
+
+/**
+ * The four families for Perspectives, loaded once for this route segment and
+ * exposed as CSS variables that perspectives.css reads (--font-fraunces, etc.).
+ * The typographic split is the argument in miniature: one man wrote (Newsreader),
+ * the other was recorded (IBM Plex Mono).
+ */
+
+// Display. The WONK/SOFT/opsz axes are used directly in perspectives.css, so
+// they must be requested here beyond the default weight axis.
+const fraunces = Fraunces({
+  subsets: ['latin'],
+  axes: ['SOFT', 'WONK', 'opsz'],
+  variable: '--font-fraunces',
+  display: 'swap',
+});
+
+// The notebook: a reading serif, because the father composed his words.
+const newsreader = Newsreader({
+  subsets: ['latin'],
+  style: ['normal', 'italic'],
+  variable: '--font-newsreader',
+  display: 'swap',
+});
+
+// The tapes: transcript type, because a machine captured his.
+const plexMono = IBM_Plex_Mono({
+  subsets: ['latin'],
+  weight: ['300', '400'],
+  variable: '--font-plex-mono',
+  display: 'swap',
+});
+
+// Dates, refs, labels: utility only.
+const plexSans = IBM_Plex_Sans({
+  subsets: ['latin'],
+  weight: ['400', '600'],
+  variable: '--font-plex-sans',
+  display: 'swap',
+});
+
+export const metadata: Metadata = {
+  title: 'Perspectives — Arete Academy',
+  description:
+    'Socratic intellectualism read through paired first-person documents rather than exposition.',
+};
+
+export default function PerspectivesLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className={`${fraunces.variable} ${newsreader.variable} ${plexMono.variable} ${plexSans.variable}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/academy/web/src/app/perspectives/perspectives.css
+++ b/academy/web/src/app/perspectives/perspectives.css
@@ -1,0 +1,153 @@
+/* Perspectives, Arete Academy
+ *
+ * Scoped under .pv so it cannot leak into the rest of the app.
+ * The four families are loaded once in app/perspectives/layout.tsx via
+ * next/font (Fraunces with SOFT/WONK/opsz axes, Newsreader, IBM Plex Mono,
+ * IBM Plex Sans) and exposed as CSS variables on the route wrapper:
+ *   --font-fraunces, --font-newsreader, --font-plex-mono, --font-plex-sans.
+ *
+ * Signature: the page is split into two grounds, paper on the left and tape
+ * on the right, and the canon card is the only element that straddles both.
+ * On narrow screens the split becomes a stack and the card spans full width.
+ */
+
+.pv {
+  --paper:#E4E5DC;
+  --paper-rule:#C9CCBE;
+  --ink:#23282A;
+  --ink-soft:#5B635E;
+  --tape:#16140F;
+  --tape-rule:#332F26;
+  --bone:#C9C4B6;
+  --bone-dim:#7C7565;
+  --slate:#1D2124;
+  --pom:#8A2B2B;
+  --pom-lit:#B8473F;
+  --measure:34rem;
+  --gap:clamp(1.5rem,4vw,4rem);
+  --display:var(--font-fraunces),"Fraunces",Georgia,serif;
+  --book:var(--font-newsreader),"Newsreader",Georgia,serif;
+  --mono:var(--font-plex-mono),"IBM Plex Mono",ui-monospace,monospace;
+  --util:var(--font-plex-sans),"IBM Plex Sans",system-ui,sans-serif;
+}
+.pv *{box-sizing:border-box}
+:root{scroll-behavior:smooth}
+.pv{margin:0;background:var(--paper);color:var(--ink);font-family:var(--book);
+  font-size:clamp(1rem,.96rem + .2vw,1.075rem);line-height:1.62;
+  -webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}
+:focus-visible{outline:2px solid var(--pom-lit);outline-offset:3px}
+
+/* ---------- hero ---------- */
+.pv-hero{min-height:88vh;display:flex;flex-direction:column;justify-content:center;
+  padding:clamp(3rem,8vh,7rem) var(--gap);position:relative;
+  background:linear-gradient(to right,var(--paper) 0 50%,var(--tape) 50% 100%)}
+.pv-eyebrow{font-family:var(--util);font-size:.72rem;font-weight:600;letter-spacing:.22em;
+  text-transform:uppercase;color:#fff;mix-blend-mode:difference;text-align:center;margin:0 0 2.5rem}
+.pv-hero h1{font-family:var(--display);font-variation-settings:"SOFT" 0,"WONK" 1,"opsz" 144;
+  font-weight:400;font-size:clamp(2.6rem,9vw,6.4rem);line-height:.95;letter-spacing:-.025em;
+  text-align:center;margin:0;color:#fff;mix-blend-mode:difference;max-width:16ch;
+  margin-inline:auto;text-wrap:balance}
+.pv-standfirst{font-family:var(--book);font-style:italic;font-size:clamp(1.05rem,2.2vw,1.4rem);
+  text-align:center;max-width:32ch;margin:1.6rem auto 0;color:#fff;mix-blend-mode:difference;line-height:1.4}
+.pv-seamline{position:absolute;left:50%;top:0;bottom:0;width:1px;background:var(--pom);opacity:.55}
+@media (max-width:820px){
+  .pv-hero{background:var(--tape);min-height:auto;padding-block:clamp(3.5rem,14vh,6rem)}
+  .pv-hero h1,.pv-standfirst,.pv-eyebrow{mix-blend-mode:normal;color:var(--paper)}
+  .pv-standfirst{color:var(--bone)}
+  .pv-seamline{display:none}
+}
+
+/* ---------- essay ---------- */
+.pv-essay{padding:clamp(3.5rem,10vh,7rem) var(--gap);background:var(--paper)}
+.pv-essay-in{max-width:var(--measure);margin:0 auto}
+.pv-essay p{margin:0 0 1.15em;font-size:1.09rem}
+.pv-essay p:first-of-type::first-letter{font-family:var(--display);font-variation-settings:"WONK" 1;
+  float:left;font-size:3.9rem;line-height:.82;padding:.06em .12em 0 0;color:var(--pom)}
+.pv-epigraph{max-width:var(--measure);margin:0 auto clamp(2.5rem,6vh,4rem);
+  border-left:2px solid var(--pom);padding-left:1.4rem}
+.pv-epigraph q{font-family:var(--display);font-variation-settings:"WONK" 1;font-size:1.28rem;
+  line-height:1.42;quotes:none;display:block;margin-bottom:.7rem}
+.pv-epigraph cite{font-family:var(--util);font-style:normal;font-size:.72rem;letter-spacing:.16em;
+  text-transform:uppercase;color:var(--ink-soft)}
+.pv-howto{max-width:var(--measure);margin:2.6rem auto 0;padding-top:1.6rem;
+  border-top:1px solid var(--paper-rule);font-size:.96rem;color:var(--ink-soft)}
+.pv-howto p{margin:0 0 .9em}
+
+/* ---------- bands ---------- */
+.pv-band{background:linear-gradient(to right,var(--paper) 0 50%,var(--tape) 50% 100%);
+  padding:0 0 clamp(3rem,7vh,5.5rem);position:relative}
+.pv-band::before{content:"";position:absolute;left:50%;top:0;bottom:0;width:1px;
+  background:var(--pom);opacity:.4}
+.pv-band-head{display:flex;align-items:center;gap:1.1rem;padding:clamp(2.5rem,7vh,4.5rem) var(--gap) clamp(1.6rem,4vh,2.6rem)}
+.pv-rule{flex:1;height:1px;background:var(--pom);opacity:.4}
+.pv-band-date{font-family:var(--util);font-size:.76rem;font-weight:600;letter-spacing:.24em;
+  text-transform:uppercase;margin:0;color:#fff;mix-blend-mode:difference;white-space:nowrap;
+  display:flex;align-items:baseline;gap:.6rem}
+.pv-yr{font-weight:400;opacity:.55;letter-spacing:.18em}
+.pv-cols{display:grid;grid-template-columns:1fr 1fr;gap:0}
+.pv-col{padding:0 var(--gap)}
+.pv-col-paper{padding-right:calc(var(--gap) * .75)}
+.pv-col-tape{padding-left:calc(var(--gap) * .75)}
+.pv-col-tag{font-family:var(--util);font-size:.66rem;font-weight:600;letter-spacing:.2em;
+  text-transform:uppercase;margin:0 0 1.5rem;padding-bottom:.55rem}
+.pv-col-paper .pv-col-tag{color:var(--ink-soft);border-bottom:1px solid var(--paper-rule)}
+.pv-col-tape .pv-col-tag{color:var(--bone-dim);border-bottom:1px solid var(--tape-rule)}
+p.pv-ink{margin:0 0 1.05em;max-width:38rem;color:var(--ink)}
+p.pv-mono{margin:0 0 1.05em;max-width:38rem;color:var(--bone);font-family:var(--mono);
+  font-size:.92rem;line-height:1.72;font-weight:300}
+
+/* ---------- canon: the only thing that touches both grounds ---------- */
+.pv-canon{position:relative;z-index:2;max-width:41rem;margin:clamp(2.6rem,6vh,4rem) auto 0;
+  background:var(--slate);color:var(--bone);padding:2rem clamp(1.5rem,3.5vw,2.6rem) 2.1rem;
+  border-top:2px solid var(--pom);box-shadow:0 24px 60px -28px rgba(0,0,0,.7)}
+.pv-canon-ref{font-family:var(--util);font-size:.68rem;font-weight:600;letter-spacing:.2em;
+  text-transform:uppercase;color:var(--pom-lit);margin:0 0 1.15rem;display:flex;
+  align-items:center;gap:.55rem}
+.pv-dot{width:6px;height:6px;background:var(--pom-lit);transform:rotate(45deg);flex:none}
+.pv-sep{opacity:.45}
+.pv-canon-q{font-family:var(--display);font-variation-settings:"WONK" 1,"opsz" 40;font-weight:300;
+  font-size:1.2rem;line-height:1.44;margin:0 0 1.3rem;color:#EDE9DE;text-wrap:pretty}
+.pv-canon-note{margin:0;font-family:var(--book);font-size:1rem;line-height:1.66;color:#A8A396}
+
+/* ---------- close ---------- */
+.pv-close{background:var(--tape);color:var(--bone);padding:clamp(4rem,11vh,8rem) var(--gap)}
+.pv-close-in{max-width:var(--measure);margin:0 auto}
+.pv-close h3{font-family:var(--display);font-variation-settings:"WONK" 1;font-weight:400;
+  font-size:clamp(1.8rem,4.5vw,2.7rem);line-height:1.06;margin:0 0 1.6rem;color:var(--paper)}
+.pv-close p{margin:0 0 1.1em}
+.pv-close ol{margin:1.6rem 0;padding-left:0;list-style:none;counter-reset:s}
+.pv-close li{counter-increment:s;margin-bottom:1.1rem;padding-left:2.4rem;position:relative}
+.pv-close li::before{content:counter(s);position:absolute;left:0;top:.05em;font-family:var(--util);
+  font-size:.72rem;font-weight:600;letter-spacing:.1em;color:var(--pom-lit);
+  border:1px solid var(--pom);width:1.5rem;height:1.5rem;display:grid;place-items:center}
+.pv-close strong{color:var(--paper);font-weight:600}
+.pv-warn{border-left:2px solid var(--pom);padding-left:1.3rem;font-size:.97rem;color:var(--bone-dim);margin-top:2rem}
+.pv-cta{display:inline-block;margin-top:2.4rem;font-family:var(--util);font-size:.76rem;font-weight:600;
+  letter-spacing:.18em;text-transform:uppercase;color:var(--tape);background:var(--paper);
+  padding:.95rem 1.6rem;text-decoration:none;transition:background .2s}
+.pv-cta:hover{background:var(--pom-lit);color:var(--paper)}
+.pv-foot{background:var(--tape);color:var(--bone-dim);padding:0 var(--gap) clamp(3rem,7vh,5rem);
+  font-family:var(--util);font-size:.78rem;line-height:1.65}
+.pv-foot-in{max-width:var(--measure);margin:0 auto;border-top:1px solid var(--tape-rule);padding-top:1.6rem}
+
+/* ---------- motion ---------- */
+.pv-reveal{opacity:0;transform:translateY(10px);transition:opacity .7s ease,transform .7s ease}
+.pv-reveal.pv-in{opacity:1;transform:none}
+@media (prefers-reduced-motion:reduce){
+  :root{scroll-behavior:auto}
+  .pv-reveal{opacity:1;transform:none;transition:none}
+}
+
+/* ---------- mobile: the split becomes a stack ---------- */
+@media (max-width:820px){
+  .pv-band{background:var(--paper);padding-bottom:0}
+  .pv-band::before{display:none}
+  .pv-band-head{background:var(--tape);margin:0;padding-block:1.6rem}
+  .pv-band-date{mix-blend-mode:normal;color:var(--bone)}
+  .pv-rule{opacity:.55}
+  .pv-cols{grid-template-columns:1fr}
+  .pv-col{padding:clamp(2rem,6vw,2.6rem) var(--gap)}
+  .pv-col-paper{background:var(--paper)}
+  .pv-col-tape{background:var(--tape)}
+  .pv-canon{margin:0 auto;max-width:none;border-top-width:2px}
+}

--- a/academy/web/src/components/perspectives/Reveal.tsx
+++ b/academy/web/src/components/perspectives/Reveal.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+/**
+ * Scroll reveal for the canon cards. Respects prefers-reduced-motion by
+ * rendering visible immediately and never registering an observer.
+ */
+export default function Reveal({
+  children,
+  className = "",
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  const ref = useRef<HTMLElement>(null);
+  const [shown, setShown] = useState(false);
+
+  useEffect(() => {
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (reduced || !("IntersectionObserver" in window)) {
+      setShown(true);
+      return;
+    }
+    const el = ref.current;
+    if (!el) return;
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setShown(true);
+            io.unobserve(entry.target);
+          }
+        }
+      },
+      { rootMargin: "0px 0px -12% 0px" }
+    );
+
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  return (
+    <aside ref={ref} className={`${className} pv-reveal${shown ? " pv-in" : ""}`}>
+      {children}
+    </aside>
+  );
+}

--- a/academy/web/src/content/perspectives/index.ts
+++ b/academy/web/src/content/perspectives/index.ts
@@ -1,0 +1,53 @@
+import raw from "./notebook-and-tapes.json";
+
+/**
+ * Perspectives content model.
+ *
+ * `canon` records are shaped to line up with the immutable canon layer of the
+ * Arete corpus. `work` + `textRef` are the natural key. When the read only MCP
+ * server over the corpus is live, swap `rendering` for a lookup against the
+ * canonical passage and keep `note` here, since the note is derived commentary
+ * and belongs in the synthesis layer rather than the canon layer.
+ */
+export type CanonRef = {
+  work: string;
+  /** Standard citation, stable across editions. e.g. "Enchiridion 5" */
+  text_ref: string;
+  /** Close paraphrase from a public domain translation. Swap for corpus text. */
+  rendering: string;
+  /** Derived commentary. Explains why this passage reads these two entries. */
+  note?: string;
+};
+
+export type Entry = {
+  date: string;
+  year: string;
+  notebook: string[];
+  tape: string[];
+  canon: CanonRef;
+};
+
+export type Column = { label: string; byline: string; note: string };
+
+export type Perspective = {
+  slug: string;
+  series: string;
+  title: string;
+  standfirst: string;
+  epigraph: CanonRef;
+  left: Column;
+  right: Column;
+  entries: Entry[];
+};
+
+const all: Perspective[] = [raw as Perspective];
+
+export const perspectives = all;
+
+export function getPerspective(slug: string): Perspective | undefined {
+  return all.find((p) => p.slug === slug);
+}
+
+export function allSlugs(): string[] {
+  return all.map((p) => p.slug);
+}

--- a/academy/web/src/content/perspectives/notebook-and-tapes.json
+++ b/academy/web/src/content/perspectives/notebook-and-tapes.json
@@ -1,0 +1,282 @@
+{
+  "slug": "the-notebook-and-the-tapes",
+  "series": "Perspectives",
+  "title": "The Notebook and the Tapes",
+  "standfirst": "Nine days of one war, held in two minds that cannot reach each other.",
+  "epigraph": {
+    "work": "Marcus Aurelius",
+    "text_ref": "Meditations VII.26",
+    "rendering": "When a man does you wrong, consider at once what conception of good or evil he had when he did it. For when you see that, you will pity him, and not be surprised or angry."
+  },
+  "left": {
+    "label": "The Notebook",
+    "byline": "Bijan Rahmani, Tehranpars, Tehran",
+    "note": "Kept in his daughter's green school exercise book, returned in her bag."
+  },
+  "right": {
+    "label": "The Tapes",
+    "byline": "The President, dictated for an authorized memoir",
+    "note": "Transcribed by a ghostwriter who is present but never recorded."
+  },
+  "entries": [
+    {
+      "date": "3 March",
+      "year": "2026",
+      "notebook": [
+        "They gave me back her bag on Sunday. It was in a pile with forty others behind the mosque on Farjam Street and a young man with a clipboard was writing names on masking tape. He asked me twice how to spell Rahmani. He was maybe nineteen. His hands were shaking worse than mine.",
+        "The bag is pink with a cartoon fox on it. The strap is torn but the buckle still works. Inside there was a water bottle, still half full, and a pencil case, and this notebook.",
+        "I am writing in her notebook. On the first eleven pages there is her handwriting. Multiplication tables. A drawing of our neighbor's cat with the ears too big. On page four she has written her full name eight times in a row, practicing, each one a little neater than the last, because she was proud that her name was long.",
+        "Yasaman.",
+        "I do not know what else to say. Roya has not spoken since Tuesday. She sits in the kitchen with the light off. My mother came from Karaj and cooked for two days and then went home because there was no one to feed.",
+        "Milad has not cried. He is fifteen. He watches the ceiling.",
+        "They hit the transformer station and the building beside it, and the school is one hundred and sixty meters from the transformer station. I have measured it on the map with my thumb. One hundred and sixty meters. She was nine years old."
+      ],
+      "tape": [
+        "Are we going? Are we rolling? Is that thing on. Okay.",
+        "So the thing you have to understand, and put this near the front, is that four presidents sat in that chair and did nothing. Nothing. They talked. They had their frameworks. Frameworks. Do you know what a framework is? It's what you call a plan when you have no intention of ever doing anything. I inherited the mess, I always inherit the mess, and in four days I did what they couldn't do in twenty five years.",
+        "The footage. Have you seen the footage? Marisol, have Danny pull the footage for her. The night vision. It looked like a movie except it was real, that's the difference, everybody's seen the movie version and this was the actual thing. The ratings that night were enormous. Enormous. Bigger than the Super Bowl if you count the streams, and they don't count the streams, they never count the streams because they don't want you to know.",
+        "And they said I wouldn't do it. For a year. He talks, he won't pull the trigger, he's all talk. Every single one of those people is very quiet now. Very quiet. Some of them have called. I didn't take the calls.",
+        "The Supreme Leader thing, look, I'm not going to sit here and be dishonest with you, that was not a small decision. That was the biggest decision anybody's made in that room in fifty years. Coyle wanted it. Everybody wanted it, they all wanted it, but nobody would say it out loud because if you say it out loud it's on you, and that's the whole business, that's the entire business right there. Grown men, fifty five, sixty years old, with the résumés, and not one of them will finish a sentence. So I finished it for them. I said fine, but it has to be clean, and it was clean. Surgical. The most precise weapons ever built, and we built them, we have the best of everything now because I rebuilt it after they let it rot.",
+        "They're already running the sad stuff. A school, some transformer, I don't know. Look, I feel badly, I do, I have children, I have grandchildren, but you cannot fight a war where they hide everything next to a school. That's their choice. They put it there. They know we won't hit it so they put it there and then when we hit it, and by the way we didn't hit it, we hit the target next to it, they run to the cameras. It's a strategy. It's actually a very effective strategy and I'd almost respect it if it wasn't so disgusting.",
+        "Anyway. Big week. Historic week. Let's do more tomorrow, I'm tired, it's been four days of no sleep and I'm sharper right now than any of them are at nine in the morning after eight hours, which, put that in."
+      ],
+      "canon": {
+        "work": "Epictetus",
+        "text_ref": "Enchiridion 5",
+        "rendering": "Men are disturbed not by things, but by the judgments they form about things.",
+        "note": "The two men receive the same four days. One receives them as the largest decision made in that room in fifty years. One receives them as a torn pink strap and a bottle still half full. Nothing in the events settles which of these is correct, because the events are not doing the work. The assent is doing the work. Begin here, because everything after this is the machinery of that one sentence running for five months."
+      }
+    },
+    {
+      "date": "19 March",
+      "year": "2026",
+      "notebook": [
+        "Tomorrow is the New Year and the year is going to turn whether I permit it or not. This is the part nobody warns you about. The world does not pause for you. The equinox arrives on schedule.",
+        "Roya set the sofreh anyway. I came home and there it was on the floor of the living room, the cloth, the mirror, the wheat sprouting in its dish because she planted it two weeks ago out of a habit older than her grief. She put out the goldfish. She put out the coins and the garlic and the vinegar. Then she sat back on her heels and looked at it for a long time and said, very quietly, that she had bought seven of everything before, and now there was one of us missing and the number seven still worked, and she could not explain why that felt like an insult.",
+        "Two nights ago was Chaharshanbe Suri. In our street some boys lit a fire in a barrel and jumped it, the way I did when I was their age, the way I did with her last year holding both her hands so she could clear it. Zardi-ye man az to, sorkhi-ye to az man. My yellow to you, your red to me. Give me your health and take my sickness.",
+        "I could hear the anti aircraft over Ekbatan while they were jumping. Someone shouted at them to put it out because of the aircraft, and someone else shouted back that the whole sky was already lit, so what did one barrel matter.",
+        "He was right. But they put it out anyway."
+      ],
+      "tape": [
+        "Okay so the strait.",
+        "NOBODY. TOLD ME. THEY COULD DO THAT.",
+        "I want that in the book exactly like that. Capital letters. I don't care how it looks. Because everybody's going to try to rewrite this later and I want it on the record while it's fresh. I sat in that room in January and I said, what about the strait, and I was told, and I'm not going to name him yet because he's supposedly a friend of mine, I was told that it would take them weeks to close it and that we could reopen it in days. Weeks to close. Days to reopen.",
+        "Eleven hours. ELEVEN HOURS.",
+        "And here's the thing that nobody will say. These are the smartest people in the world, allegedly. Allegedly! The models, the assessments, the twelve agencies, the man has a doctorate, and I asked one question, one, off the top of my head, sitting there, no briefing book, and the one question I asked is the exact thing that happened. I am the only person in that building who asked it. Explain that to me. Explain to me how a guy from Queens with no doctorate is the only one in the room who thought of the ocean.",
+        "I'll tell you how. Because they don't think. They retrieve. They go get the last memo and they change the date on it.",
+        "So now gas is what it is and every gas station in America has a number on a sign and that number is my number, that's how they'll play it, it's never their number it's always mine. The same people who begged me to do this, and they did beg, I have the room, I know who was in the room, are now writing that gas is high. You watch. Six months from now not one of them will admit they were there.",
+        "Look, I'd rather have the deal. I've always said that. Go find the post, I said I would rather have a Deal than not have a Deal, and if they had taken it not one person would have been hurt. Not one. That's on them.",
+        "And can I say something. They negotiate like they won. It's insane. I'm looking at satellite of their entire air defense, gone, doesn't exist, and their guy is reading me a list. A list! Marty says it's cultural, they always open impossible, it's a bazaar thing. Fine. But at some point somebody has to be realistic and it isn't going to be me because I'm holding everything.",
+        "What else. The knee is fine. Somebody put the knee thing out there and I want to know who, because that came from inside, that did not come from a photographer. I walked the whole colonnade twice yesterday and Danny timed it."
+      ],
+      "canon": {
+        "work": "Epictetus",
+        "text_ref": "Enchiridion 5",
+        "rendering": "To blame others for your own troubles is the mark of a beginner. To blame yourself is the mark of one who has started. To blame no one is the mark of one whose schooling is finished.",
+        "note": "Three sentences into the second session the president reaches for the first stage and stays there for the remaining eight months. Notice that he is not lying. Someone did give him a bad estimate on the strait. The claim is true and it is still the move that ends his education, because once the failure has an author who is not him there is nothing left to examine. The father is on the same ladder facing the other way, and by the fourth entry he is furious at his own government as well, which is not wisdom yet but is at least the second rung."
+      }
+    },
+    {
+      "date": "10 April",
+      "year": "2026",
+      "notebook": [
+        "Forty days.",
+        "We went to Behesht e Zahra this morning. There is a section now that did not exist in February and it is not full, which is the thing I cannot stop thinking about. There is room. Somebody has planned for room.",
+        "My brother called from Vancouver again. Third time this month. He wants us to try for Turkey, he says he has a friend, he says there are still ways. He talks fast, the way people talk when they are ashamed of where they are standing. I told him the airports are closed and the roads east are checkpoints and Roya will not leave the country that has Yasaman in the ground in it. He said, Bijan, she is not in the ground, she is with God. I said that is very easy to say from a place where nothing falls out of the sky.",
+        "Then I hung up and sat in the car in the parking lot of the cemetery for twenty minutes and I was so ashamed of myself I could not go back in to my wife.",
+        "I want to write down what I actually feel, since no one asks me and no one will.",
+        "I do not think the men who did this know that our street exists. That is the part. If they hated me it would be simpler. Hate is a relationship. This is not a relationship. Some person read a grid reference off a screen and my daughter was inside the rounding error. They will say the transformer station was a legitimate military target and maybe by their books it was, I am not a lawyer, I fix water mains.",
+        "But I would like to say this to whoever it was, quite calmly. She was learning multiplication. She could do the sevens but not the eights. Her name was long and she was proud of it. You did not kill an argument about a nuclear program. You killed a person who was working on her eights."
+      ],
+      "tape": [
+        "Dover was very hard. I want to talk about Dover.",
+        "Nobody tells you about that part. You stand there and they bring them off the plane and there's a family and they look at you. They look right at you. And I did it, I stood there the whole time, I didn't rush it, some presidents rush it, I've seen them check the watch, I don't check the watch.",
+        "The mother said something to me and I said something back and I'm not going to repeat it because it was private, but I'll tell you, people came up to me afterward, career people, tough people, and said that was the best they'd ever seen anyone handle it. Including some who worked for the other guy. They said nobody does that like you do.",
+        "That's the part they'll never write. Never. They'll write forty stories about a school in Tehran that we did not hit and zero about me standing on that tarmac at six in the morning in the cold.",
+        "And by the way. Who told them my schedule. Because there were three outlets that had the Dover trip before it was announced and there are maybe nine people who knew. Nine. I've asked for the list. I've asked twice. Danny says it's not worth the fight right now and I said Danny, everything is the fight, that IS the fight, there is nothing else.",
+        "Where are we. Six weeks. Longer than I wanted, I'll say that, I thought this would be a two week thing, three weeks. But you cannot judge it at six weeks and any person who does is either stupid or dishonest and honestly most of them are both. Nobody judged the last one at six weeks. The objectives are met, the program is finished, that's done, that's forever, that's the thing that lasts a hundred years after everybody in this room is dead.",
+        "The blockade goes in this week. Coyle's people say thirty days and they're on their knees. I said give me the real number, not the number you think I want, the real one, and he said thirty days. So we'll see what thirty days means. I've been given a lot of thirty days in my life."
+      ],
+      "canon": {
+        "work": "Epictetus",
+        "text_ref": "Enchiridion 16",
+        "rendering": "When you see a man weeping in grief, do not be carried off by the appearance. Say first that it is not the loss that afflicts him, since another bears the same loss lightly, but the judgment he has made about it. Do not refuse to console him with words, and even to grieve with him outwardly. But take care that you do not also grieve inwardly.",
+        "note": "Epictetus is describing a difficult discipline: full outward presence, no inward collapse. The president at Dover performs the outward half flawlessly and then grades the performance, twice, and reports that career people said nobody does it like he does. The inward half never occurs. This is the passage most often misread as permission for coldness. Read against the tarmac it becomes a diagnostic instead, and it is worth asking which half you would fail."
+      }
+    },
+    {
+      "date": "28 April",
+      "year": "2026",
+      "notebook": [
+        "The blockade is two weeks old and the city has started to change shape.",
+        "At work we are down to one shift because the pumping station at Kan has been running on the diesel generator since the grid attacks and there is no diesel to spare, so we rotate the pressure by district. This is my job now. Deciding which neighborhoods get water in the morning and which get it at night. Yesterday a woman on Delavaran screamed at me in the street for eleven minutes because her mother is on dialysis and the tank on the roof was empty. I stood there and let her. She was correct. There was nothing to say back to her.",
+        "Prices. I write them down because in a year I will not believe them. Chicken has tripled since February. Cooking oil you buy from a man, not a shop. The pharmacy on the corner has a handwritten list taped inside the glass of what they do not have, and the list is longer than the shelves. Insulin is on the list. My aunt's chemotherapy is on the list. They tell us on the radio that medicine is exempt from the blockade, and technically this is true, and technically it does not matter, because no shipping company on earth will send a hull into that water for the sake of a container of ampoules.",
+        "So the exemption is real and the medicine is not real. I have thought about this a lot while sitting in traffic. It is a very modern kind of cruelty. Nobody has to sign anything.",
+        "And here is the other half, and I will write it even though I would burn this notebook before letting anyone read it. There are men in this city whose families flew out in the first week. Everybody knows which ones. We have been told for twenty years to endure for the sake of resistance and I have endured, I have endured the sanctions and the inflation and the shutdowns and the humiliation of watching my salary become a joke, and I would endure more, but not for them. Not for the ones who evacuated their children.",
+        "I am being crushed between two things and only one of them is dropping bombs. That does not make the other one my friend."
+      ],
+      "tape": [
+        "Good session today, I want to do the business side, the book needs the business side, that's what people actually want and the publisher knows it even if she won't say it.",
+        "So while all this is happening, and this is what nobody understands about me, I'm also doing the biggest deals in the history of that region. The fund. The fund is going to be the largest sovereign vehicle ever assembled and they came to me, I want to be very clear about the direction of that, they came to me, because there's one person over there they trust and it isn't the State Department. The State Department has been wrong about that region for sixty consecutive years. Sixty! You could flip a coin and do better. You could take a man off the street.",
+        "Is there a family involvement, they'll ask that, they always ask that. Jared's people are separate. Completely separate entity, everything reviewed by lawyers, the best lawyers, and frankly if my family isn't allowed to work then no president's family could ever work and that's not America. My kids are very talented. Very talented. More talented than me in some ways, not all ways.",
+        "The tower is not a conflict. Somebody wrote that the tower is a conflict. The tower is a BUILDING. It's a beautiful building, tallest in the region, and it happens to be in a country that is an ally, and if I stopped every project everywhere I'd have to stop being a businessman, which they'd love, that's actually the whole game, that has always been the game, they want me poor and quiet.",
+        "Now. Hollis. I have to do Hollis for the record.",
+        "General Hollis came to me Friday and gave me the whole thing. The off ramp. We need an off ramp, sir. The stockpiles, sir. And I let him talk, I always let them talk, I let a man hang himself with his own rope because it saves me the trouble.",
+        "Here's what I've learned in eighty years about a certain kind of guy, and there's one in every organization, and he is ALWAYS very impressive looking. Great posture. Beautiful haircut. Speaks in that low voice like he's in a documentary about himself. And what he actually wants, underneath all of it, is for nothing to happen, ever, because nothing happening is the only thing that can never be blamed on him.",
+        "That's not courage. Everybody calls that courage now. That's a man protecting a pension.",
+        "And then, and THEN, forty eight hours later the exact language he used with me is in the paper. The exact language. Off ramp. Two words, his words, in print. So either he leaked it himself or he told somebody who leaked it, and there is no third option, Marisol, don't look at me like that, there is no third door in that room. I know exactly what a man is doing when his private warning to me becomes his public record.",
+        "He's not warning me. He's building an alibi."
+      ],
+      "canon": {
+        "work": "Epictetus",
+        "text_ref": "Discourses II.22",
+        "rendering": "Wherever a man places his I and his mine, there he must incline.",
+        "note": "The whole entry is one doctrine demonstrated twice. The president has placed his I in the fund, the tower, the family's standing and the appearance of strength, so his judgment inclines there without any felt sensation of bending. And because he assumes every man is built the same way, he can only read General Hollis one way: a man protecting a pension. He is not being cynical. He is being consistent. He has no available theory of a person who has placed his I somewhere else."
+      }
+    },
+    {
+      "date": "8 May",
+      "year": "2026",
+      "notebook": [
+        "They called it a ceasefire for nine days and then last night the sky opened again over the south of the city and once over Tehran, and this morning the word ceasefire is just a sound people make.",
+        "Nothing else to report. Milad asked me at breakfast what the word means if it can be turned off. I did not have an answer so I told him to eat."
+      ],
+      "tape": [
+        "Short one. I'm not in the mood.",
+        "They hit our ships, we hit back. That's the story. I'm not going to apologize for it during a ceasefire or during anything else. You break it, you own it.",
+        "And I barely made that call, by the way. Write that down. That was Coyle's package, it came to me at the end of a nineteen hour day, and I said if it's clean, go. That's what I said. Four words. If it's clean, go.",
+        "Now. Ask Danny, quietly, not in an email, whether the second wave was in the package I approved or whether it got added downstream. Because I've gone back over it in my head maybe forty times and I do not remember a second wave. I remember one. And if somebody put a second wave under my four words then that is a very, very serious thing and I want to know it before somebody else knows it.",
+        "Ask him verbally. Not in an email. Marisol, that part's not for the book, that's a note."
+      ],
+      "canon": {
+        "work": "Epictetus",
+        "text_ref": "Discourses I.28",
+        "rendering": "Every error contains a contradiction. The one who errs does not wish to err, but has been forced by what appeared true to him.",
+        "note": "The shortest entries in both documents sit on the doctrinal center of the page. He said if it is clean, go. Four words of assent, given at the end of a long day, and then a note to check afterward whether the second wave was even in the package he saw. Socratic intellectualism is not the claim that he meant well. It is the harder claim that the moment of assent is the whole moral event, and that a mind trained to skip it will produce atrocity while experiencing itself as barely involved."
+      }
+    },
+    {
+      "date": "21 June",
+      "year": "2026",
+      "notebook": [
+        "There is a document now. A memorandum. They are calling it a path to ending the war and it was signed by people I could not pick out of a photograph, and for four days this house has been infected with hope, which I did not expect and did not want.",
+        "Hope is dangerous in the way that standing up too fast is dangerous. You forget you have been on the floor.",
+        "Roya went to the bazaar on Tuesday for the first time since March. She came back with fabric. She is going to make curtains for the back room. She has not made anything since Yasaman, and she stood in the doorway with the bag in her hand and looked at me almost defiantly, as if daring me to say it was too soon, and I said the color was good. It is a kind of green. It is not a color I would have picked. It is the best thing that has happened in this house in four months.",
+        "I went back to full days at the department. There is talk of restoring the eastern line. I caught myself planning something for October and had to sit down.",
+        "Here is what I have understood about the shape of this. I used to think grief was a weight you carry and slowly put down. It is not. It is a room you live in, and some days the door is open and you walk out into the street and you are a man buying bread, and then you turn around and you are back inside it and you were never anywhere else. Yasaman is in every room in this house. I do not want that fixed. If someone offered me a medicine that made me stop feeling this I would refuse it, because the feeling is the last place she is still doing anything."
+      ],
+      "tape": [
+        "Okay. Okay okay okay.",
+        "So we have peace.",
+        "The prize thing, before anything else, because they'll ask. I don't care about it. Everyone knows I don't care about it, it's been made into this whole thing. They gave it to men who did nothing. They gave it to a man for a SPEECH. And I ended a war between the United States and Iran, and if they don't give it to me it simply confirms what I've said about that entire operation since the beginning. But I don't care. Put it in lightly.",
+        "Now let me describe the actual moment, because you cannot get this from the coverage.",
+        "Marty called at four in the morning, which he never does, and he said sir they signed, and I'll be honest with you, I sat on the edge of the bed in the dark and I said thank God. Out loud. Alone. I'm not a person who does that, you know I'm not, and I don't want it framed as a religious thing because it wasn't, it was just what came out.",
+        "A hundred and thirteen days. That's what it took. And every single person who said I would blunder into a forever war is now looking at a signed document.",
+        "You know what I keep thinking about, and this is a strange thing for me to say into a machine.",
+        "I'm eighty. Everybody knows the number, the number's the number, they run it every week like it's news. And I look at what the other ones did with the last part, the paintings, the library with the little theater, and I think, no. Not for me. This. This is the thing. Forty years from now there's a kid in Tehran who's alive who wouldn't have been, and he'll never know my name, and that's fine. That's actually fine.",
+        "Okay, enough, I'm getting sentimental, it's late. But keep it. Actually keep that, that one's good."
+      ],
+      "canon": {
+        "work": "Marcus Aurelius",
+        "text_ref": "Meditations V.6",
+        "rendering": "One man, when he has done a service, is ready to enter it in the account as a favor owed. Another is not ready to do that, but in his own mind he thinks of the man as in his debt. A third, in a way, does not even know what he has done. He is like a vine that has produced grapes and asks nothing more once it has borne its fruit.",
+        "note": "This is the entry where he is closest to good, and Marcus explains exactly why it does not hold. He sits on the edge of the bed at four in the morning and says thank God, alone, and then says keep it, actually keep it, that one's good. The vine does not review the tape. Do not read this as catching him out. Read it as the reason the June opening closed within days: a good that has to be witnessed is not yet stable enough to survive the first insult."
+      }
+    },
+    {
+      "date": "9 July",
+      "year": "2026",
+      "notebook": [
+        "It is over. The memorandum, I mean. Two days ago the American president said the truce was finished and now the ships are burning again in the strait and last night the phones lost signal for six hours.",
+        "I want to record what happened in this house on Tuesday because I am afraid of it.",
+        "Milad came home and told me, in the doorway, with his shoes still on, that he had been to speak to someone about volunteering. He is fifteen. He said it the way boys say things they have rehearsed in their heads on the walk home. He said he cannot sit in a room and do nothing while they do this to us. He said Yasaman's name to me, which he has not done since March, and he used it like a stone.",
+        "I hit him. I have never hit either of my children. I hit my son across the face in the hallway of my own home and Roya came out of the kitchen and the three of us stood there.",
+        "Then I put my arms around him and I said, I have one child left, and I do not care about anything else in the world, and he cried finally, four months late, standing up, into my shoulder.",
+        "I do not know if I have stopped him or delayed him.",
+        "Let me be honest here, since this book is the only place I am honest. I understand him. There is a thing in my chest that wants what he wants. When I read that they hit a fuel depot and killed nobody I am disappointed, and I have to sit with the fact that I am the kind of man who is disappointed by that now. In February I was not that man. This is what they have done, and I do not think they have the faintest idea they are doing it. They think they are destroying centrifuges. They are manufacturing fifteen year olds."
+      ],
+      "tape": [
+        "THEY PLAYED ME.",
+        "I want the word played in the book. I want it in the chapter title if we can do it. Chapter Nineteen, Played. Let them run that.",
+        "They signed that document with no intention, NONE, ZERO, of honoring one line of it, and they used those days to move assets and reposition and get back in the water, and now there are people, there are people in this town, who are going to write that I was naive. Naive! After Ninety Three years of these people and I'm the naive one! I gave them a chance. That is all that was. Any decent person gives the other side one chance and they showed the entire world what they are.",
+        "So the truce is over. I said it Monday and I meant it and this time there is no version where I stop early. None.",
+        "Now I want to say something and I want it in the book.",
+        "They knew. Somebody told them.",
+        "You do not sign on a Thursday and start repositioning on a Friday unless you already know what we're going to do about it. Somebody in this building, or at the Pentagon, or in one of these twelve agencies that couldn't find the ocean, is telling them what my limits are. And I know how that sounds. I know exactly how that sounds, Marisol, you can stop writing for a second. But explain to me the timing. Explain the timing to me and I'll drop it.",
+        "Nobody can explain the timing.",
+        "And here's what I want understood, and I want you to write this well, because this is the center of the entire book. I am not an angry man. I know what they say. I am the least angry person you will ever meet in a room like that, ask anyone who's actually been in the room, ask Hollis, he'll tell you, he'll tell you I'm the calmest one in there. But there is a difference between being angry and knowing precisely who did what to you. I know precisely who did what to me. And the entire history of the world, all of it, is people underestimating what happens next.",
+        "They think I'll get bored. That's their strategy. Three of my own people have told me that's the read over there, that the American gets bored, he loses interest, he moves on. Eighty years old and the whole plan of a nation of ninety million people is that I'll get tired.",
+        "We'll see who gets tired."
+      ],
+      "canon": {
+        "work": "Seneca",
+        "text_ref": "On Anger, II.35 and III.5",
+        "rendering": "Anger is an appetite for repaying pain, and there is no swifter road to madness. See what wreckage it makes of cities and of households.",
+        "note": "Two men are injured within days of each other and both convert the injury into a program. The president wants the word played in a chapter title. Milad, at fifteen, goes to speak to someone about volunteering. Seneca's point is not that anger is unpleasant but that it is a form of belief: it contains the judgment that harm has been done and that repayment is good. Both judgments feel like perception rather than opinion, which is why the only person in either document who interrupts the sequence has to do it with his hands, in a hallway, and is ashamed."
+      }
+    },
+    {
+      "date": "2 August",
+      "year": "2026",
+      "notebook": [
+        "I am going to write carefully now and then I am going to move this notebook.",
+        "They took Reza's nephew on Thursday. Twenty three years old, works at a phone repair kiosk on Resalat, and the charge is contact with a hostile service. Reza says the boy sold a used handset to someone. That is what Reza says. I do not know what is true. What I know is the number, because the number gets out even now: hundreds this year, dozens last month alone, and every week the rope and the announcement afterward.",
+        "So this is the country in August. Above us the aircraft. Around us the men who are so frightened of us that they have started killing us at a pace they did not manage in peacetime. The bombing gave them the thing they always wanted, which is an emergency, and inside an emergency there is no such thing as an innocent question.",
+        "Nobody outside will hold both of these in their head at once. To the Americans I am a regime. To the regime I am a suspect. There is no room anywhere in the world for me to stand and be simply a man from Tehranpars whose daughter died and who would like the water pressure restored in district nine.",
+        "I heard a number on a foreign broadcast last week. One hundred and sixty eight children. I know that number is a claim, and I know somebody in an office somewhere is preparing a document arguing that the real figure is lower, and they may even be right. Yasaman is somewhere inside that number. She has become a data point in a dispute between two governments about whose arithmetic is more honest. That is what has happened to my daughter. She was a person who liked the cat with the big ears and now she is evidence.",
+        "I am putting this book behind the water heater tonight."
+      ],
+      "tape": [
+        "Four in the morning. Can't sleep. Just talk, I'll fix it later.",
+        "The leaks. There's a report going around about civilian numbers and somebody handed it to the Hill and it's already out, and I want two things on the record. One, the report says we were careful, which we WERE, more careful than any military in the history of warfare. Two, whoever leaked it committed treason, and I've said that publicly and I'll say it here.",
+        "It's the same nine people. It's the same nine people from Dover and I still don't have the list.",
+        "I've started thinking about who's in the room when I say things. That's not paranoia, that's arithmetic, that's just subtraction. You take what came out, you take who heard it, and you're left with a number. I've done this my whole life in business and every single time, every time, the number was right and the person was somebody I'd have vouched for that morning.",
+        "And you know what nobody wants to talk about. They're hanging people. Their own. Four hundred and forty four this year, kids in phone shops, hanging them in a yard, and where's the outrage. WHERE. Not one of these organizations that has an opinion about me every eleven minutes has said a word. That's who we're dealing with and that's who I'm supposed to make a deal with, and then be lectured about a transformer station.",
+        "Anyway.",
+        "Anyway.",
+        "I keep, and this is off the record, I keep coming back to. There's a photograph. Danny's people flagged it because it was going around. A girl. One of the ones from the first week. And I looked at it for probably longer than I should have and then I put it face down on the desk.",
+        "And the thing is, I don't have anything to do with that. I want to be very clear. I didn't do that. The people who put a military site next to a school did that. The four presidents who let it get to this point did that. Honestly her own government did that, they had every chance, every chance, and they spent it.",
+        "But I looked at it.",
+        "Marisol. Is this machine on right now. It's on. Okay. Take that last stretch out, from the photograph. Leave the four hundred and forty four. Take the rest, and I want the file, not a copy, the file."
+      ],
+      "canon": {
+        "work": "Marcus Aurelius",
+        "text_ref": "Meditations III.11",
+        "rendering": "Make for yourself a definition of the thing presented: see it stripped, whole, and divided into what it is made of, and name it, and name the parts it will be resolved into.",
+        "note": "The central Stoic discipline is to look at the impression until you can say what it actually is. Both men are refusing the same exercise on the same night, in opposite directions. He looks at the photograph longer than he should, puts it face down, produces three fluent reasons why it has nothing to do with him, and then asks for the passage to be cut. The father hides his notebook behind the water heater, for the reverse reason: he has looked too clearly to be safe writing it down. One is protected from examination by power. One is prevented from it by fear."
+      }
+    },
+    {
+      "date": "14 August",
+      "year": "2026",
+      "notebook": [
+        "Quiet week. Two nights with nothing overhead. You learn to hear the quiet as a held breath rather than as peace, but I will take it.",
+        "The pomegranate in the yard has set fruit. It is a bad tree, it has always been a bad tree, my father in law planted it in the wrong corner in 1994 and it gets four hours of sun and produces maybe nine fruit in a good year. Yasaman was the one who cared about it. She used to count them in July and report the number to me at dinner like a foreman.",
+        "There are eleven this year. Eleven. The best it has ever done.",
+        "I stood out there yesterday evening for a long time, longer than I meant to, and I want to write down what I thought, because it was not what I expected to think.",
+        "I thought: I am not going to get justice. There will be no moment. No one is coming to this house to say her name and mean it. There will be a settlement or an exhaustion or a new government or a slow forgetting, and in ten years this will be a chapter with a name in somebody's book, and I will be a man in his fifties with a bad back and one son.",
+        "And under that I thought: I will not become the thing that did this. That is the only piece of it I control. I have almost no power in my life now. I cannot protect my family, I cannot leave, I cannot vote for anything that matters, I cannot even guarantee water on the fourth floor of a building on Delavaran on a Tuesday. But I can decide what I turn into. Milad watches me. He will take his shape from what he sees me do, and if what he sees is a man who kept working, who did not hand himself over to the hatred, who counted pomegranates, then something survives that they cannot reach with any munition they have.",
+        "That is not forgiveness. I want to be extremely clear about that, in case anyone ever reads this. I do not forgive them. I do not forgive the ones who ordered it or the ones who justified it afterward or the comfortable people who watched it on a screen and thought about something else within the hour. I hope they are made to look at what they did, in detail, by name, one child at a time.",
+        "But I am not going to spend what is left of my life inside that. She would not have known me.",
+        "Roya finished the curtains. They are up. The green is still not a color I would have picked."
+      ],
+      "tape": [
+        "Good week. Quiet week. They're calling from Oman. They're always calling from Oman, they call from Oman the way other people breathe.",
+        "We're doing the library on the water, I've decided. Not a museum. Museums are for dead men. This is going to be a working institute, and there'll be the room, we're recreating the room, the actual table, and you walk in and the screens are showing what I was seeing that night, and you stand where I stood.",
+        "Kids come through on the buses. That's the part I like. Some kid from nowhere walks in and sees what it actually takes. Because everybody has an opinion about the decision and about eleven human beings who have ever lived have had to make one.",
+        "Was it worth it. They'll ask that in every interview for the rest of my life and I want the answer in the book so I never have to say it again. The answer is you don't get to ask that yet. You ask that in fifty years. Nobody was asking Truman in year one. They were killing Lincoln in the papers in year two, year two, and now he's on the money and the men who wrote those columns are not on anything.",
+        "History is not written by people crying on television. It gets written later. By serious people. With the whole picture.",
+        "That's the last line of the book. Use that.",
+        "And Marisol. Before you go. The session from the second, the late one, where I was tired and I was talking about the photograph. Did you take that out or is it still sitting somewhere.",
+        "Take it out. And the transcript, and whatever's on the card, and if there's a backup somewhere I want to know where the backup is, because I've been doing this a long time and there is always a backup.",
+        "Take it out."
+      ],
+      "canon": {
+        "work": "Epictetus",
+        "text_ref": "Enchiridion 1",
+        "rendering": "Some things are up to us and some are not. Up to us are judgment, impulse, desire, aversion, and in a word whatever is our own doing. Not up to us are the body, property, reputation, office, and in a word whatever is not our own doing.",
+        "note": "The father arrives at the division without the vocabulary. He lists what he cannot do, which is nearly everything, and then says that what he turns into is the only piece he controls, and that his son will take his shape from it. That is prohairesis stated by a water engineer in a yard. The president spends his final session on the library, the buses, the recreated room, and history written later by serious people, which is to say he stakes the entire account on reputation. He is not less intelligent than the father. He has simply drawn the line in the one place where nothing can ever be secured, and he will spend the rest of his life defending ground that was never his."
+      }
+    }
+  ]
+}

--- a/academy/web/src/middleware.ts
+++ b/academy/web/src/middleware.ts
@@ -10,8 +10,10 @@ import type { NextRequest } from 'next/server'
 // The Observatory proxies (/api/observatory/*) are public for the same
 // reason — they surface only approved, observatory_visible data and the
 // Railway backend rate-limits the one interactive route (passage).
+//
+// Perspectives (/perspectives/*) is a public essay surface, like the Library.
 const PUBLIC_ROUTES = ['/', '/waitlist', '/login', '/signup', '/library', '/api/oracle', '/api/linkedin-callback', '/api/cron/post-due']
-const PUBLIC_PREFIXES = ['/api/library/', '/api/observatory/']
+const PUBLIC_PREFIXES = ['/api/library/', '/api/observatory/', '/perspectives/']
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl


### PR DESCRIPTION
Adds the /perspectives/[slug] route for academy.pursuearete.com, a paired first-person diptych demonstrating Socratic intellectualism. Content lives in src/content/perspectives (JSON source of truth + typed loader); the route, scoped CSS, and a scroll-reveal client component render it. A segment layout loads the four type families (Fraunces w/ SOFT/WONK/opsz axes, Newsreader, IBM Plex Mono, IBM Plex Sans) via next/font, following the library/ pattern.

Marks /perspectives/* public in middleware, like the Library surface.

Resolves at /perspectives/the-notebook-and-the-tapes.