### PR TITLE
Perspectives essay + Arete AI playground

### DIFF
--- a/academy/supabase/migrations/006_playground_comments.sql
+++ b/academy/supabase/migrations/006_playground_comments.sql
@@ -1,0 +1,39 @@
+-- Playground: the corpus discussion board.
+--
+-- One table backs every discussion thread across the AI playground — the
+-- perspective essays and the situations game — keyed by `thread_key`
+-- (e.g. 'perspective:the-notebook-and-the-tapes' or 'situation:the-slow-line').
+--
+-- A visitor posts a comment (optionally taking a stance), and the corpus
+-- answers it; the corpus reply is a second row with author_role='corpus' and
+-- parent_id pointing back at the visitor's comment.
+--
+-- RLS: anyone may READ the board (it is a public surface, like Perspectives and
+-- the Library). Writes are performed only by the server via the service-role
+-- key (which bypasses RLS), so there is no anon INSERT policy — the browser can
+-- never write directly, which keeps the corpus reply and the rate limit under
+-- server control.
+
+create table if not exists public.playground_comments (
+  id          uuid primary key default gen_random_uuid(),
+  thread_key  text not null,
+  author_role text not null default 'visitor'
+              check (author_role in ('visitor', 'corpus')),
+  author_name text,
+  stance      text check (stance in ('agree', 'disagree', 'unsure')),
+  body        text not null check (char_length(body) between 1 and 4000),
+  parent_id   uuid references public.playground_comments(id) on delete cascade,
+  sources     jsonb,
+  created_at  timestamptz not null default now()
+);
+
+create index if not exists playground_comments_thread_idx
+  on public.playground_comments (thread_key, created_at);
+
+alter table public.playground_comments enable row level security;
+
+drop policy if exists "playground_comments public read" on public.playground_comments;
+create policy "playground_comments public read"
+  on public.playground_comments
+  for select
+  using (true);

--- a/academy/web/src/app/api/playground/comments/route.ts
+++ b/academy/web/src/app/api/playground/comments/route.ts
@@ -1,0 +1,196 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createAdminClient } from '@/lib/supabase-admin';
+
+/**
+ * The playground discussion board.
+ *
+ * GET  /api/playground/comments?thread=<key>
+ *   → { comments: Comment[] }  (oldest first; corpus replies carry parent_id)
+ *
+ * POST /api/playground/comments
+ *   body: { thread, context, stance?, name?, body }
+ *   → persists the visitor comment, asks the corpus to answer it, persists the
+ *     corpus reply, and returns { comment, reply }.
+ *
+ * The corpus voice is the same public Oracle that powers the Library — the
+ * whole tradition answering at once (author = null). We call the Railway
+ * backend directly from the server so the reply can be persisted in one hop and
+ * the shared daily rate limit is enforced upstream exactly as elsewhere.
+ */
+
+const BACKEND_URL =
+  process.env.RAILWAY_BACKEND_URL ||
+  process.env.NEXT_PUBLIC_API_BASE_URL ||
+  'https://arete-app-production.up.railway.app';
+
+type Stance = 'agree' | 'disagree' | 'unsure';
+
+// The Oracle caps `question` at 500 chars (it drives both RAG retrieval and the
+// final user turn), so the stance tag must stay compact.
+const STANCE_TAG: Record<Stance, string> = {
+  agree: '[The reader agrees with the position.] ',
+  disagree: '[The reader disagrees with the position.] ',
+  unsure: '[The reader is unsure about the position.] ',
+};
+const QUESTION_MAX = 500;
+
+function isStance(v: unknown): v is Stance {
+  return v === 'agree' || v === 'disagree' || v === 'unsure';
+}
+
+export async function GET(request: NextRequest) {
+  const thread = request.nextUrl.searchParams.get('thread');
+  if (!thread) {
+    return NextResponse.json({ error: 'Missing thread' }, { status: 400 });
+  }
+  try {
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from('playground_comments')
+      .select('id, thread_key, author_role, author_name, stance, body, parent_id, sources, created_at')
+      .eq('thread_key', thread)
+      .order('created_at', { ascending: true });
+    if (error) throw error;
+    return NextResponse.json({ comments: data ?? [] });
+  } catch (err) {
+    console.error('[api/playground/comments GET]', err);
+    return NextResponse.json({ error: 'Could not load the discussion.' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  let payload: {
+    thread?: unknown;
+    context?: unknown;
+    stance?: unknown;
+    name?: unknown;
+    body?: unknown;
+  };
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body.' }, { status: 400 });
+  }
+
+  const thread = typeof payload.thread === 'string' ? payload.thread.trim() : '';
+  const context = typeof payload.context === 'string' ? payload.context.trim() : '';
+  const body = typeof payload.body === 'string' ? payload.body.trim() : '';
+  const stance = isStance(payload.stance) ? payload.stance : null;
+  const rawName = typeof payload.name === 'string' ? payload.name.trim() : '';
+  const name = rawName ? rawName.slice(0, 80) : null;
+
+  if (!thread) return NextResponse.json({ error: 'Missing thread.' }, { status: 400 });
+  if (!body) return NextResponse.json({ error: 'Write a comment first.' }, { status: 400 });
+  if (body.length > 4000) {
+    return NextResponse.json({ error: 'Comment is too long (4000 characters max).' }, { status: 400 });
+  }
+
+  const supabase = createAdminClient();
+
+  // 1. Persist the visitor's comment.
+  const { data: comment, error: insertErr } = await supabase
+    .from('playground_comments')
+    .insert({
+      thread_key: thread,
+      author_role: 'visitor',
+      author_name: name,
+      stance,
+      body,
+    })
+    .select('id, thread_key, author_role, author_name, stance, body, parent_id, sources, created_at')
+    .single();
+
+  if (insertErr || !comment) {
+    console.error('[api/playground/comments POST insert]', insertErr);
+    return NextResponse.json({ error: 'Could not save your comment.' }, { status: 500 });
+  }
+
+  // 2. Ask the corpus to answer it. The essay/situation context and the
+  //    instructions ride in `history` (unbounded); `question` stays short — the
+  //    reader's stance + comment — because the Oracle caps it at 500 chars and
+  //    retrieves the corpus from it.
+  const { question, history } = buildCorpusPrompt({ context, stance, body });
+  let reply = null;
+  let remaining: number | null = null;
+
+  try {
+    const upstream = await fetch(`${BACKEND_URL}/oracle`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ question, author: null, history }),
+    });
+    if (upstream.ok) {
+      const data = await upstream.json();
+      const answer = typeof data.answer === 'string' ? data.answer.trim() : '';
+      if (typeof data.remaining === 'number') remaining = data.remaining;
+      if (answer) {
+        const { data: replyRow, error: replyErr } = await supabase
+          .from('playground_comments')
+          .insert({
+            thread_key: thread,
+            author_role: 'corpus',
+            author_name: null,
+            stance: null,
+            body: answer,
+            parent_id: comment.id,
+            sources: data.sources ?? null,
+          })
+          .select('id, thread_key, author_role, author_name, stance, body, parent_id, sources, created_at')
+          .single();
+        if (replyErr) {
+          console.error('[api/playground/comments POST reply insert]', replyErr);
+        } else {
+          reply = replyRow;
+        }
+      }
+    } else {
+      console.error('[api/playground/comments POST oracle]', upstream.status, await upstream.text());
+    }
+  } catch (err) {
+    console.error('[api/playground/comments POST oracle fetch]', err);
+  }
+
+  // The comment is saved even if the corpus was silent; the reply may be null.
+  return NextResponse.json({ comment, reply, remaining });
+}
+
+type HistoryTurn = { role: 'user' | 'assistant'; content: string };
+
+/**
+ * Splits the corpus prompt across the Oracle's two inputs:
+ *   - `history`: the essay/situation context and the instruction to engage,
+ *     as a primed user→assistant exchange (not length-limited upstream).
+ *   - `question`: the reader's stance + comment, capped at 500 chars — this is
+ *     both the RAG retrieval query and the final user turn.
+ */
+function buildCorpusPrompt(args: {
+  context: string;
+  stance: Stance | null;
+  body: string;
+}): { question: string; history: HistoryTurn[] } {
+  const { context, stance, body } = args;
+
+  const instruction =
+    "Respond to the reader's next message from within the Stoic tradition and the " +
+    'wider corpus. Engage their actual claim: grant what is right in it and press ' +
+    'where it goes wrong, citing specific passages where they bear. Address the ' +
+    'reader directly, in the voice of the house, and take a position — do not merely ' +
+    'summarize.';
+
+  const framing = context
+    ? `The reader is responding to this:\n\n${context}\n\n${instruction}`
+    : instruction;
+
+  const history: HistoryTurn[] = [
+    { role: 'user', content: framing },
+    { role: 'assistant', content: 'Understood — I have that context in view. What does the reader say?' },
+  ];
+
+  const tag = stance ? STANCE_TAG[stance] : '';
+  let question = `${tag}${body}`.trim();
+  if (question.length > QUESTION_MAX) {
+    question = question.slice(0, QUESTION_MAX - 1).trimEnd() + '…';
+  }
+
+  return { question, history };
+}

--- a/academy/web/src/app/perspectives/[slug]/page.tsx
+++ b/academy/web/src/app/perspectives/[slug]/page.tsx
@@ -1,9 +1,8 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import Link from "next/link";
 
 import { allSlugs, getPerspective } from "@/content/perspectives";
-import Reveal from "@/components/perspectives/Reveal";
+import PerspectiveArticle from "@/components/perspectives/PerspectiveArticle";
 import "../perspectives.css";
 
 export function generateStaticParams() {
@@ -25,25 +24,6 @@ export async function generateMetadata({
   };
 }
 
-const ESSAY = [
-  "Socrates held that no one does wrong willingly. Not that wrongdoing is rare, and not that it is excusable, but that every action is aimed at something the agent takes to be good, so that when the aim is monstrous the failure lies in the taking. Vice is a defect of sight before it is a defect of will.",
-  "This is the easiest doctrine in the school to agree with and the hardest to hold for longer than a paragraph. It survives contact with the careless driver and the difficult colleague. It collapses the moment you meet someone whose error has a body count, because at that point the mind reaches for a simpler instrument, which is the villain.",
-  "What follows is built to make the doctrine difficult rather than comfortable. Two documents cover the same nine days of the same war. On the left, a father in east Tehran writes in the exercise book that came home in his nine year old daughter's school bag. On the right, the man who ordered the strike dictates his memoir into a recorder, in a room with no one in it who will contradict him.",
-  "Neither man believes he is doing wrong. One of them is right about that.",
-];
-
-const HOWTO = [
-  "Read across, not down. The pairing is the argument, and the dates are matched deliberately, so the entry that takes the father forty days of mourning is the entry in which the president grades his own performance on a tarmac at six in the morning.",
-  "Between the two columns, at the foot of each day, the canon reads both men at once. It is the only voice on this page that can see both.",
-];
-
-const STEPS = [
-  ["Write their account in the first person.", "Not a confession and not a satire. The version in which they are the reasonable party, the version they would recognize, containing the true grievances as well as the false ones."],
-  ["Find the assent.", "Somewhere in what you have written there is a moment where a false impression was accepted as fact. Mark it. It is almost never at the dramatic point. It is usually early, small, and phrased as something obvious."],
-  ["Name the good they were reaching for.", "Safety, standing, loyalty, the protection of someone. It will be a real good, aimed at badly. If you cannot find one you have not finished step one."],
-  ["Find the same move in your own week.", "This is the step people skip, and it is the only one that changes anything."],
-];
-
 export default async function PerspectivePage({
   params,
 }: {
@@ -53,119 +33,5 @@ export default async function PerspectivePage({
   const p = getPerspective(slug);
   if (!p) notFound();
 
-  return (
-    <main className="pv">
-      <header className="pv-hero">
-        <span className="pv-seamline" aria-hidden="true" />
-        <p className="pv-eyebrow">
-          {p.series} <span aria-hidden="true">&middot;</span> Arete Academy
-        </p>
-        <h1>{p.title}</h1>
-        <p className="pv-standfirst">{p.standfirst}</p>
-      </header>
-
-      <section className="pv-essay">
-        <div className="pv-epigraph">
-          <q>{p.epigraph.rendering}</q>
-          <cite>
-            {p.epigraph.work} <span aria-hidden="true">/</span> {p.epigraph.text_ref}
-          </cite>
-        </div>
-        <div className="pv-essay-in">
-          {ESSAY.map((t, i) => (
-            <p key={i}>{t}</p>
-          ))}
-          <div className="pv-howto">
-            {HOWTO.map((t, i) => (
-              <p key={i}>{t}</p>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {p.entries.map((e, i) => (
-        <section className="pv-band" key={e.date} aria-labelledby={`pv-d${i}`}>
-          <div className="pv-band-head">
-            <span className="pv-rule" aria-hidden="true" />
-            <h2 id={`pv-d${i}`} className="pv-band-date">
-              {e.date}
-              <span className="pv-yr">{e.year}</span>
-            </h2>
-            <span className="pv-rule" aria-hidden="true" />
-          </div>
-
-          <div className="pv-cols">
-            <div className="pv-col pv-col-paper">
-              <p className="pv-col-tag">{p.left.label}</p>
-              {e.notebook.map((t, j) => (
-                <p className="pv-ink" key={j}>
-                  {t}
-                </p>
-              ))}
-            </div>
-            <div className="pv-col pv-col-tape">
-              <p className="pv-col-tag">{p.right.label}</p>
-              {e.tape.map((t, j) => (
-                <p className="pv-mono" key={j}>
-                  {t}
-                </p>
-              ))}
-            </div>
-          </div>
-
-          <Reveal className="pv-canon">
-            <p className="pv-canon-ref">
-              <span className="pv-dot" aria-hidden="true" />
-              {e.canon.work}
-              <span className="pv-sep">/</span>
-              {e.canon.text_ref}
-            </p>
-            <blockquote className="pv-canon-q">{e.canon.rendering}</blockquote>
-            {e.canon.note ? <p className="pv-canon-note">{e.canon.note}</p> : null}
-          </Reveal>
-        </section>
-      ))}
-
-      <section className="pv-close">
-        <div className="pv-close-in">
-          <h3>The exercise</h3>
-          <p>
-            Choose someone whose conduct you find indefensible. Not a stranger in the
-            news. Someone whose actions have cost you something.
-          </p>
-          <ol>
-            {STEPS.map(([head, body]) => (
-              <li key={head}>
-                <strong>{head}</strong> {body}
-              </li>
-            ))}
-          </ol>
-          <p className="pv-warn">
-            A caution, since this exercise is regularly misunderstood as a route to
-            forgiveness. It is not, and Marcus never claims it is. The father is
-            explicit in his last entry that he does not forgive and hopes the
-            responsible are made to look at what they did, by name, one child at a
-            time. Understanding the mechanism of another person&rsquo;s error tells you
-            what happened. It does not tell you what is owed. Those are separate
-            questions and the school keeps them separate.
-          </p>
-          <Link className="pv-cta" href="/courses/phil-706">
-            Study this in PHIL 706
-          </Link>
-        </div>
-      </section>
-
-      <footer className="pv-foot">
-        <div className="pv-foot-in">
-          <p>
-            Both documents are fiction. The father, the president, their families and
-            their staff are invented. The chronology of the war is drawn from the public
-            record of 2026. Canon renderings are close paraphrase from public domain
-            translations and carry the standard references so they can be read against
-            any edition.
-          </p>
-        </div>
-      </footer>
-    </main>
-  );
+  return <PerspectiveArticle p={p} />;
 }

--- a/academy/web/src/app/playground/layout.tsx
+++ b/academy/web/src/app/playground/layout.tsx
@@ -1,0 +1,56 @@
+import type { Metadata } from 'next';
+import { Fraunces, Newsreader, IBM_Plex_Mono, IBM_Plex_Sans } from 'next/font/google';
+import './playground.css';
+
+/**
+ * The Arete AI Playground — a place to test ideas against the corpus.
+ *
+ * It borrows the four type families from Perspectives so an essay dropped into
+ * the playground reads the same, and adds the discussion board on top. The
+ * fonts are exposed as CSS variables (--font-fraunces, etc.) that both
+ * playground.css and perspectives.css read.
+ */
+
+const fraunces = Fraunces({
+  subsets: ['latin'],
+  axes: ['SOFT', 'WONK', 'opsz'],
+  variable: '--font-fraunces',
+  display: 'swap',
+});
+
+const newsreader = Newsreader({
+  subsets: ['latin'],
+  style: ['normal', 'italic'],
+  variable: '--font-newsreader',
+  display: 'swap',
+});
+
+const plexMono = IBM_Plex_Mono({
+  subsets: ['latin'],
+  weight: ['300', '400'],
+  variable: '--font-plex-mono',
+  display: 'swap',
+});
+
+const plexSans = IBM_Plex_Sans({
+  subsets: ['latin'],
+  weight: ['400', '600'],
+  variable: '--font-plex-sans',
+  display: 'swap',
+});
+
+export const metadata: Metadata = {
+  title: 'The Playground — Arete Academy',
+  description:
+    'An experimental workshop for testing ideas against the corpus — perspective essays, the situations game, and an open line to the tradition.',
+};
+
+export default function PlaygroundLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className={`${fraunces.variable} ${newsreader.variable} ${plexMono.variable} ${plexSans.variable}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/academy/web/src/app/playground/page.tsx
+++ b/academy/web/src/app/playground/page.tsx
@@ -1,0 +1,53 @@
+import Link from 'next/link';
+import { perspectives } from '@/content/perspectives';
+import { situations } from '@/content/playground/situations';
+
+/**
+ * The Playground hub — an index of experiments. Each card links to a surface
+ * where an idea is put to the corpus: the perspective essays and the
+ * situations game today, with room to add more.
+ */
+export default function PlaygroundHub() {
+  const featured = perspectives[0];
+
+  return (
+    <main className="pg">
+      <header className="pg-hero">
+        <p className="pg-eyebrow">Arete Academy · Workshop</p>
+        <h1>The Playground</h1>
+        <p className="pg-lede">
+          A workshop for testing ideas against the tradition. Read, take a side,
+          and let the corpus answer back.
+        </p>
+      </header>
+
+      <div className="pg-grid">
+        {featured ? (
+          <Link className="pg-card" href={`/playground/perspectives/${featured.slug}`}>
+            <p className="pg-card-kicker">Perspectives</p>
+            <h2>{featured.title}</h2>
+            <p>{featured.standfirst}</p>
+            <span className="pg-card-go">Read &amp; discuss →</span>
+          </Link>
+        ) : null}
+
+        <Link className="pg-card" href="/playground/situations">
+          <p className="pg-card-kicker">The Situations Game</p>
+          <h2>What would the school say?</h2>
+          <p>
+            {situations.length} everyday situations, each with the response the
+            tradition would give — then argue it out with the corpus.
+          </p>
+          <span className="pg-card-go">Play →</span>
+        </Link>
+
+        <div className="pg-card pg-card-soon" aria-disabled="true">
+          <p className="pg-card-kicker">Coming soon</p>
+          <h2>More experiments</h2>
+          <p>New ways to pressure-test the doctrine are on the bench.</p>
+          <span className="pg-card-go">In progress</span>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/academy/web/src/app/playground/perspectives/[slug]/page.tsx
+++ b/academy/web/src/app/playground/perspectives/[slug]/page.tsx
@@ -1,0 +1,76 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+
+import { allSlugs, getPerspective } from "@/content/perspectives";
+import PerspectiveArticle from "@/components/perspectives/PerspectiveArticle";
+import CorpusDiscussion from "@/components/playground/CorpusDiscussion";
+import "../../../perspectives/perspectives.css";
+
+export function generateStaticParams() {
+  return allSlugs().map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const p = getPerspective(slug);
+  if (!p) return {};
+  return {
+    title: `${p.title} — Playground | Arete Academy`,
+    description: p.standfirst,
+  };
+}
+
+export default async function PlaygroundPerspectivePage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const p = getPerspective(slug);
+  if (!p) notFound();
+
+  // What the corpus is told the reader is responding to, so its replies land
+  // against the actual argument rather than in the abstract.
+  const context =
+    `The perspective essay "${p.title}" (${p.series}). Standfirst: ${p.standfirst} ` +
+    `The essay presses the Socratic doctrine that no one does wrong willingly — that ` +
+    `every action aims at some apparent good, so vice is a defect of sight before it is ` +
+    `a defect of will. It pairs two first-person documents from the same nine days of a ` +
+    `war: a bereaved father's notebook and the president's dictated memoir. The reader ` +
+    `may be agreeing or disagreeing with the outcome of the essay, with the essay itself, ` +
+    `or with the underlying claim that no one does wrong on purpose.`;
+
+  return (
+    <div className="pg" style={{ background: "var(--paper)" }}>
+      <div style={{ background: "var(--tape)", padding: "1.2rem var(--gap)" }}>
+        <Link className="pg-back" href="/playground" style={{ margin: 0 }}>
+          ← The Playground
+        </Link>
+      </div>
+
+      <PerspectiveArticle p={p} />
+
+      <div style={{ background: "var(--tape)" }}>
+        <div style={{ maxWidth: "48rem", margin: "0 auto" }}>
+          <CorpusDiscussion
+            threadKey={`perspective:${p.slug}`}
+            context={context}
+            heading="Argue it with the corpus"
+            intro={
+              "Where do you land? You can agree or disagree with the outcome, with the " +
+              "essay itself, or with the claim underneath it — that no one does wrong on " +
+              "purpose. Post your view and the corpus will answer, granting what is right " +
+              "in it and pressing where it goes wrong."
+            }
+            placeholder="e.g. 'The president knew exactly what he was doing — the no-one-does-wrong-willingly line lets him off the hook.'"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/academy/web/src/app/playground/playground.css
+++ b/academy/web/src/app/playground/playground.css
@@ -1,0 +1,491 @@
+/* The Playground, Arete Academy
+ *
+ * Two scopes live here:
+ *   .pg  — the playground hub and situations surfaces
+ *   .cd  — the corpus discussion board, reused on every playground page
+ *
+ * Both share the Perspectives palette so an essay pulled into the playground
+ * reads continuously. The fonts come from app/playground/layout.tsx.
+ */
+
+.pg,
+.cd {
+  --paper: #e4e5dc;
+  --paper-rule: #c9ccbe;
+  --ink: #23282a;
+  --ink-soft: #5b635e;
+  --tape: #16140f;
+  --tape-rule: #332f26;
+  --bone: #c9c4b6;
+  --bone-dim: #7c7565;
+  --slate: #1d2124;
+  --pom: #8a2b2b;
+  --pom-lit: #b8473f;
+  --measure: 40rem;
+  --gap: clamp(1.5rem, 4vw, 4rem);
+  --display: var(--font-fraunces), 'Fraunces', Georgia, serif;
+  --book: var(--font-newsreader), 'Newsreader', Georgia, serif;
+  --mono: var(--font-plex-mono), 'IBM Plex Mono', ui-monospace, monospace;
+  --util: var(--font-plex-sans), 'IBM Plex Sans', system-ui, sans-serif;
+}
+.pg *,
+.cd * {
+  box-sizing: border-box;
+}
+
+/* ============================ hub ============================ */
+.pg {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--tape);
+  color: var(--bone);
+  font-family: var(--book);
+  font-size: clamp(1rem, 0.96rem + 0.2vw, 1.075rem);
+  line-height: 1.62;
+  -webkit-font-smoothing: antialiased;
+}
+.pg :focus-visible {
+  outline: 2px solid var(--pom-lit);
+  outline-offset: 3px;
+}
+
+.pg-hero {
+  padding: clamp(4rem, 12vh, 8rem) var(--gap) clamp(2.5rem, 6vh, 4rem);
+  max-width: 60rem;
+  margin: 0 auto;
+  position: relative;
+}
+.pg-eyebrow {
+  font-family: var(--util);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--pom-lit);
+  margin: 0 0 1.6rem;
+}
+.pg-hero h1 {
+  font-family: var(--display);
+  font-variation-settings: 'SOFT' 0, 'WONK' 1, 'opsz' 144;
+  font-weight: 400;
+  font-size: clamp(2.6rem, 8vw, 5.4rem);
+  line-height: 0.98;
+  letter-spacing: -0.025em;
+  margin: 0;
+  color: var(--paper);
+  max-width: 16ch;
+  text-wrap: balance;
+}
+.pg-lede {
+  font-family: var(--book);
+  font-style: italic;
+  font-size: clamp(1.1rem, 2.4vw, 1.5rem);
+  max-width: 40ch;
+  margin: 1.6rem 0 0;
+  color: var(--bone);
+  line-height: 1.42;
+}
+
+/* experiment cards */
+.pg-grid {
+  max-width: 60rem;
+  margin: 0 auto;
+  padding: 0 var(--gap) clamp(5rem, 12vh, 9rem);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 20rem), 1fr));
+  gap: clamp(1.2rem, 3vw, 2rem);
+}
+.pg-card {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  color: inherit;
+  background: var(--slate);
+  border-top: 2px solid var(--pom);
+  padding: clamp(1.6rem, 3.5vw, 2.4rem);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 18px 44px -30px rgba(0, 0, 0, 0.8);
+}
+.pg-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 26px 60px -30px rgba(0, 0, 0, 0.9);
+}
+.pg-card.pg-card-soon {
+  opacity: 0.5;
+  pointer-events: none;
+  border-top-color: var(--tape-rule);
+}
+.pg-card-kicker {
+  font-family: var(--util);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--pom-lit);
+  margin: 0 0 0.9rem;
+}
+.pg-card h2 {
+  font-family: var(--display);
+  font-variation-settings: 'WONK' 1;
+  font-weight: 400;
+  font-size: clamp(1.5rem, 3.4vw, 2rem);
+  line-height: 1.05;
+  margin: 0 0 0.7rem;
+  color: var(--paper);
+}
+.pg-card p {
+  margin: 0;
+  font-size: 0.98rem;
+  color: var(--bone-dim);
+  line-height: 1.55;
+}
+.pg-card-go {
+  margin-top: auto;
+  padding-top: 1.4rem;
+  font-family: var(--util);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--pom-lit);
+}
+
+/* ==================== situations game ==================== */
+.pg-sit {
+  max-width: var(--measure);
+  margin: 0 auto;
+  padding: 0 var(--gap) clamp(5rem, 12vh, 9rem);
+}
+.pg-back {
+  display: inline-block;
+  font-family: var(--util);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--bone-dim);
+  text-decoration: none;
+  margin: 0 0 2.5rem;
+}
+.pg-back:hover {
+  color: var(--pom-lit);
+}
+.pg-sit-intro {
+  margin: 0 0 clamp(2.5rem, 6vh, 4rem);
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--tape-rule);
+}
+.pg-sit-intro p {
+  margin: 0.9rem 0 0;
+  color: var(--bone-dim);
+  font-size: 1rem;
+}
+
+.pg-situation {
+  margin: 0 0 clamp(2.5rem, 6vh, 4rem);
+  border: 1px solid var(--tape-rule);
+  background: #100e0a;
+}
+.pg-situation-head {
+  padding: clamp(1.4rem, 3.5vw, 2.2rem);
+}
+.pg-sit-tag {
+  font-family: var(--util);
+  font-size: 0.64rem;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--bone-dim);
+  margin: 0 0 0.9rem;
+}
+.pg-situation h2 {
+  font-family: var(--display);
+  font-variation-settings: 'WONK' 1;
+  font-weight: 400;
+  font-size: clamp(1.4rem, 3.2vw, 1.85rem);
+  line-height: 1.12;
+  margin: 0 0 0.8rem;
+  color: var(--paper);
+}
+.pg-sit-scene {
+  margin: 0;
+  color: var(--bone);
+  font-size: 1.05rem;
+}
+.pg-sit-response {
+  background: var(--slate);
+  border-top: 2px solid var(--pom);
+  padding: clamp(1.4rem, 3.5vw, 2.2rem);
+}
+.pg-sit-response-ref {
+  font-family: var(--util);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--pom-lit);
+  margin: 0 0 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+.pg-sit-response-ref .pg-diamond {
+  width: 6px;
+  height: 6px;
+  background: var(--pom-lit);
+  transform: rotate(45deg);
+  flex: none;
+}
+.pg-sit-verdict {
+  font-family: var(--display);
+  font-variation-settings: 'WONK' 1, 'opsz' 40;
+  font-weight: 300;
+  font-size: 1.22rem;
+  line-height: 1.42;
+  margin: 0 0 1.1rem;
+  color: #ede9de;
+  text-wrap: pretty;
+}
+.pg-sit-reason {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.62;
+  color: #a8a396;
+}
+
+/* ==================== discussion board (.cd) ==================== */
+.cd {
+  font-family: var(--book);
+  color: var(--bone);
+  background: var(--tape);
+  border-top: 1px solid var(--tape-rule);
+  padding: clamp(1.6rem, 4vw, 2.6rem);
+}
+.pg-situation .cd {
+  border-top: 1px solid var(--tape-rule);
+  background: #100e0a;
+}
+.cd-head {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  margin: 0 0 0.5rem;
+}
+.cd-mark {
+  width: 7px;
+  height: 7px;
+  background: var(--pom-lit);
+  transform: rotate(45deg);
+  flex: none;
+}
+.cd-head h2 {
+  font-family: var(--util);
+  font-size: 0.74rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--bone);
+  margin: 0;
+}
+.cd-intro {
+  margin: 0 0 1.6rem;
+  color: var(--bone-dim);
+  font-size: 0.96rem;
+  max-width: 46rem;
+}
+
+.cd-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+  margin-bottom: 2rem;
+}
+.cd-empty {
+  color: var(--bone-dim);
+  font-style: italic;
+  margin: 0;
+  padding: 1.2rem 0;
+}
+.cd-thread {
+  border-left: 2px solid var(--tape-rule);
+  padding-left: clamp(0.9rem, 2.5vw, 1.4rem);
+}
+.cd-msg {
+  margin: 0 0 0.9rem;
+}
+.cd-msg:last-child {
+  margin-bottom: 0;
+}
+.cd-byline {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 0 0 0.4rem;
+}
+.cd-who {
+  font-family: var(--util);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  color: var(--bone);
+}
+.cd-corpus .cd-who {
+  color: var(--pom-lit);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+}
+.cd-dot {
+  width: 6px;
+  height: 6px;
+  background: var(--pom-lit);
+  transform: rotate(45deg);
+  flex: none;
+}
+.cd-stance {
+  font-family: var(--util);
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 0.15rem 0.5rem;
+  border: 1px solid var(--tape-rule);
+  color: var(--bone-dim);
+}
+.cd-stance-agree {
+  color: #8fb48a;
+  border-color: #3a4a36;
+}
+.cd-stance-disagree {
+  color: var(--pom-lit);
+  border-color: #4a2a28;
+}
+.cd-body {
+  margin: 0;
+  color: var(--bone);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+.cd-corpus-body {
+  color: #cfcabc;
+}
+.cd-corpus-body p {
+  margin: 0 0 0.75em;
+}
+.cd-corpus-body p:last-child {
+  margin-bottom: 0;
+}
+.cd-silent {
+  margin: 0.4rem 0 0;
+  font-style: italic;
+  color: var(--bone-dim);
+  font-size: 0.9rem;
+}
+
+/* composer */
+.cd-form {
+  border-top: 1px solid var(--tape-rule);
+  padding-top: 1.6rem;
+}
+.cd-stances {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.9rem;
+}
+.cd-chip {
+  font-family: var(--util);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  padding: 0.45rem 0.9rem;
+  background: transparent;
+  color: var(--bone-dim);
+  border: 1px solid var(--tape-rule);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.cd-chip:hover {
+  color: var(--bone);
+  border-color: var(--bone-dim);
+}
+.cd-chip-on {
+  color: var(--paper);
+  background: var(--pom);
+  border-color: var(--pom);
+}
+.cd-text {
+  width: 100%;
+  background: #100e0a;
+  border: 1px solid var(--tape-rule);
+  color: var(--paper);
+  font-family: var(--book);
+  font-size: 1rem;
+  line-height: 1.55;
+  padding: 0.9rem 1rem;
+  resize: vertical;
+  min-height: 5.5rem;
+}
+.cd-text::placeholder {
+  color: var(--bone-dim);
+}
+.cd-text:focus {
+  outline: none;
+  border-color: var(--pom);
+}
+.cd-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-top: 0.8rem;
+  align-items: center;
+}
+.cd-name {
+  flex: 1 1 12rem;
+  background: #100e0a;
+  border: 1px solid var(--tape-rule);
+  color: var(--paper);
+  font-family: var(--util);
+  font-size: 0.9rem;
+  padding: 0.7rem 0.9rem;
+}
+.cd-name::placeholder {
+  color: var(--bone-dim);
+}
+.cd-name:focus {
+  outline: none;
+  border-color: var(--pom);
+}
+.cd-submit {
+  font-family: var(--util);
+  font-size: 0.74rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--tape);
+  background: var(--paper);
+  border: none;
+  padding: 0.85rem 1.4rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+.cd-submit:hover:not(:disabled) {
+  background: var(--pom-lit);
+  color: var(--paper);
+}
+.cd-submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.cd-error {
+  margin: 0.9rem 0 0;
+  color: var(--pom-lit);
+  font-size: 0.9rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pg-card,
+  .cd-chip,
+  .cd-submit {
+    transition: none;
+  }
+}

--- a/academy/web/src/app/playground/situations/page.tsx
+++ b/academy/web/src/app/playground/situations/page.tsx
@@ -1,0 +1,97 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { situations } from "@/content/playground/situations";
+import CorpusDiscussion from "@/components/playground/CorpusDiscussion";
+
+export const metadata: Metadata = {
+  title: "The Situations Game — Playground | Arete Academy",
+  description:
+    "Everyday situations, each with the response the tradition would give — then argue the verdict with the corpus.",
+};
+
+export default function SituationsPage() {
+  return (
+    <main className="pg">
+      <div className="pg-sit">
+        <Link className="pg-back" href="/playground">
+          ← The Playground
+        </Link>
+
+        <header className="pg-sit-intro">
+          <p className="pg-eyebrow" style={{ marginBottom: "1rem" }}>
+            The Situations Game
+          </p>
+          <h1
+            style={{
+              fontFamily: "var(--display)",
+              fontVariationSettings: "'WONK' 1",
+              fontWeight: 400,
+              fontSize: "clamp(2.2rem, 6vw, 3.4rem)",
+              lineHeight: 1.02,
+              margin: 0,
+              color: "var(--paper)",
+            }}
+          >
+            What would the school say?
+          </h1>
+          <p>
+            Ordinary moments, and the response the tradition would actually give
+            — not a platitude, but the move it would make. Read the verdict, then
+            decide whether you buy it. Agree, disagree, or push back, and the
+            corpus will answer.
+          </p>
+        </header>
+
+        {situations.map((s) => (
+          <article className="pg-situation" key={s.id} id={s.id}>
+            <div className="pg-situation-head">
+              <p className="pg-sit-tag">{s.tag}</p>
+              <h2>{s.title}</h2>
+              <p className="pg-sit-scene">{s.scene}</p>
+            </div>
+
+            <div className="pg-sit-response">
+              <p className="pg-sit-response-ref">
+                <span className="pg-diamond" aria-hidden="true" />
+                {s.ref.work}
+                <span style={{ opacity: 0.45 }}>/</span>
+                {s.ref.text_ref}
+              </p>
+              <p className="pg-sit-verdict">{s.verdict}</p>
+              <p className="pg-sit-reason">{s.reason}</p>
+            </div>
+
+            <CorpusDiscussion
+              threadKey={`situation:${s.id}`}
+              context={
+                `A situation from the Situations Game — "${s.title}" (${s.tag}). ` +
+                `The scene: ${s.scene} ` +
+                `The tradition's verdict, resting on ${s.ref.work} ${s.ref.text_ref}: ` +
+                `"${s.verdict}" Reasoning: ${s.reason} ` +
+                `The reader is agreeing or disagreeing with this verdict.`
+              }
+              heading="Do you buy the verdict?"
+              placeholder="Agree, disagree, or complicate it — the corpus will answer."
+            />
+          </article>
+        ))}
+
+        <p
+          style={{
+            fontFamily: "var(--util)",
+            fontSize: "0.82rem",
+            color: "var(--bone-dim)",
+            lineHeight: 1.6,
+            borderTop: "1px solid var(--tape-rule)",
+            paddingTop: "1.6rem",
+            marginTop: "1rem",
+          }}
+        >
+          Canon renderings are close paraphrase from public-domain translations
+          and carry standard references so they can be read against any edition.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/academy/web/src/components/perspectives/PerspectiveArticle.tsx
+++ b/academy/web/src/components/perspectives/PerspectiveArticle.tsx
@@ -1,0 +1,149 @@
+import Link from "next/link";
+import type { Perspective } from "@/content/perspectives";
+import Reveal from "@/components/perspectives/Reveal";
+
+/**
+ * The Perspectives essay, rendered from a Perspective record. Extracted from
+ * the original /perspectives/[slug] page so the same article can be shown
+ * unchanged inside the Playground with the corpus discussion appended beneath.
+ *
+ * The essay/how-to/exercise prose is the frame that surrounds every paired-
+ * document perspective; the per-day columns and canon cards come from content.
+ */
+
+const ESSAY = [
+  "Socrates held that no one does wrong willingly. Not that wrongdoing is rare, and not that it is excusable, but that every action is aimed at something the agent takes to be good, so that when the aim is monstrous the failure lies in the taking. Vice is a defect of sight before it is a defect of will.",
+  "This is the easiest doctrine in the school to agree with and the hardest to hold for longer than a paragraph. It survives contact with the careless driver and the difficult colleague. It collapses the moment you meet someone whose error has a body count, because at that point the mind reaches for a simpler instrument, which is the villain.",
+  "What follows is built to make the doctrine difficult rather than comfortable. Two documents cover the same nine days of the same war. On the left, a father in east Tehran writes in the exercise book that came home in his nine year old daughter's school bag. On the right, the man who ordered the strike dictates his memoir into a recorder, in a room with no one in it who will contradict him.",
+  "Neither man believes he is doing wrong. One of them is right about that.",
+];
+
+const HOWTO = [
+  "Read across, not down. The pairing is the argument, and the dates are matched deliberately, so the entry that takes the father forty days of mourning is the entry in which the president grades his own performance on a tarmac at six in the morning.",
+  "Between the two columns, at the foot of each day, the canon reads both men at once. It is the only voice on this page that can see both.",
+];
+
+const STEPS = [
+  ["Write their account in the first person.", "Not a confession and not a satire. The version in which they are the reasonable party, the version they would recognize, containing the true grievances as well as the false ones."],
+  ["Find the assent.", "Somewhere in what you have written there is a moment where a false impression was accepted as fact. Mark it. It is almost never at the dramatic point. It is usually early, small, and phrased as something obvious."],
+  ["Name the good they were reaching for.", "Safety, standing, loyalty, the protection of someone. It will be a real good, aimed at badly. If you cannot find one you have not finished step one."],
+  ["Find the same move in your own week.", "This is the step people skip, and it is the only one that changes anything."],
+];
+
+export default function PerspectiveArticle({ p }: { p: Perspective }) {
+  return (
+    <main className="pv">
+      <header className="pv-hero">
+        <span className="pv-seamline" aria-hidden="true" />
+        <p className="pv-eyebrow">
+          {p.series} <span aria-hidden="true">&middot;</span> Arete Academy
+        </p>
+        <h1>{p.title}</h1>
+        <p className="pv-standfirst">{p.standfirst}</p>
+      </header>
+
+      <section className="pv-essay">
+        <div className="pv-epigraph">
+          <q>{p.epigraph.rendering}</q>
+          <cite>
+            {p.epigraph.work} <span aria-hidden="true">/</span> {p.epigraph.text_ref}
+          </cite>
+        </div>
+        <div className="pv-essay-in">
+          {ESSAY.map((t, i) => (
+            <p key={i}>{t}</p>
+          ))}
+          <div className="pv-howto">
+            {HOWTO.map((t, i) => (
+              <p key={i}>{t}</p>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {p.entries.map((e, i) => (
+        <section className="pv-band" key={e.date} aria-labelledby={`pv-d${i}`}>
+          <div className="pv-band-head">
+            <span className="pv-rule" aria-hidden="true" />
+            <h2 id={`pv-d${i}`} className="pv-band-date">
+              {e.date}
+              <span className="pv-yr">{e.year}</span>
+            </h2>
+            <span className="pv-rule" aria-hidden="true" />
+          </div>
+
+          <div className="pv-cols">
+            <div className="pv-col pv-col-paper">
+              <p className="pv-col-tag">{p.left.label}</p>
+              {e.notebook.map((t, j) => (
+                <p className="pv-ink" key={j}>
+                  {t}
+                </p>
+              ))}
+            </div>
+            <div className="pv-col pv-col-tape">
+              <p className="pv-col-tag">{p.right.label}</p>
+              {e.tape.map((t, j) => (
+                <p className="pv-mono" key={j}>
+                  {t}
+                </p>
+              ))}
+            </div>
+          </div>
+
+          <Reveal className="pv-canon">
+            <p className="pv-canon-ref">
+              <span className="pv-dot" aria-hidden="true" />
+              {e.canon.work}
+              <span className="pv-sep">/</span>
+              {e.canon.text_ref}
+            </p>
+            <blockquote className="pv-canon-q">{e.canon.rendering}</blockquote>
+            {e.canon.note ? <p className="pv-canon-note">{e.canon.note}</p> : null}
+          </Reveal>
+        </section>
+      ))}
+
+      <section className="pv-close">
+        <div className="pv-close-in">
+          <h3>The exercise</h3>
+          <p>
+            Choose someone whose conduct you find indefensible. Not a stranger in the
+            news. Someone whose actions have cost you something.
+          </p>
+          <ol>
+            {STEPS.map(([head, body]) => (
+              <li key={head}>
+                <strong>{head}</strong> {body}
+              </li>
+            ))}
+          </ol>
+          <p className="pv-warn">
+            A caution, since this exercise is regularly misunderstood as a route to
+            forgiveness. It is not, and Marcus never claims it is. The father is
+            explicit in his last entry that he does not forgive and hopes the
+            responsible are made to look at what they did, by name, one child at a
+            time. Understanding the mechanism of another person&rsquo;s error tells you
+            what happened. It does not tell you what is owed. Those are separate
+            questions and the school keeps them separate.
+          </p>
+          <Link className="pv-cta" href="/courses/phil-706">
+            Study this in PHIL 706
+          </Link>
+        </div>
+      </section>
+
+      <footer className="pv-foot">
+        <div className="pv-foot-in">
+          <p>
+            Both documents are fiction. The father, the president, their families and
+            their staff are invented. The chronology of the war is drawn from the public
+            record of 2026. Canon renderings are close paraphrase from public domain
+            translations and carry the standard references so they can be read against
+            any edition.
+          </p>
+        </div>
+      </footer>
+    </main>
+  );
+}

--- a/academy/web/src/components/playground/CorpusDiscussion.tsx
+++ b/academy/web/src/components/playground/CorpusDiscussion.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+/**
+ * The corpus discussion board, reused across the playground.
+ *
+ * A visitor posts a comment — optionally taking a stance (agree / disagree /
+ * unsure) toward whatever the page is arguing — and the corpus answers it.
+ * Threads are keyed by `threadKey`; the `context` string is sent to the server
+ * so the tradition can frame its reply against what the reader is responding to.
+ *
+ * Styling lives in playground.css under the `.cd-` prefix.
+ */
+
+type Comment = {
+  id: string;
+  thread_key: string;
+  author_role: "visitor" | "corpus";
+  author_name: string | null;
+  stance: "agree" | "disagree" | "unsure" | null;
+  body: string;
+  parent_id: string | null;
+  sources: unknown;
+  created_at: string;
+};
+
+type Stance = "agree" | "disagree" | "unsure";
+
+const STANCE_META: Record<Stance, { label: string; short: string }> = {
+  agree: { label: "I agree", short: "agrees" },
+  disagree: { label: "I disagree", short: "disagrees" },
+  unsure: { label: "I'm unsure", short: "unsure" },
+};
+
+export default function CorpusDiscussion({
+  threadKey,
+  context,
+  heading = "Take it up with the corpus",
+  intro,
+  placeholder = "Say where you land — and why. The corpus will answer.",
+}: {
+  threadKey: string;
+  context: string;
+  heading?: string;
+  intro?: string;
+  placeholder?: string;
+}) {
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [name, setName] = useState("");
+  const [stance, setStance] = useState<Stance | null>(null);
+  const [body, setBody] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const feedRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/playground/comments?thread=${encodeURIComponent(threadKey)}`
+        );
+        const data = await res.json();
+        if (alive && Array.isArray(data.comments)) setComments(data.comments);
+      } catch {
+        /* leave the board empty; the composer still works */
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [threadKey]);
+
+  // Pair each visitor comment with its corpus reply (parent_id === comment.id).
+  const threads = useMemo(() => {
+    const replies = new Map<string, Comment>();
+    for (const c of comments) {
+      if (c.author_role === "corpus" && c.parent_id) replies.set(c.parent_id, c);
+    }
+    return comments
+      .filter((c) => c.author_role === "visitor")
+      .map((c) => ({ comment: c, reply: replies.get(c.id) ?? null }));
+  }, [comments]);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = body.trim();
+    if (!trimmed || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/playground/comments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          thread: threadKey,
+          context,
+          stance,
+          name: name.trim() || undefined,
+          body: trimmed,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Something went wrong. Try again.");
+        return;
+      }
+      setComments((prev) => {
+        const next = [...prev];
+        if (data.comment) next.push(data.comment);
+        if (data.reply) next.push(data.reply);
+        return next;
+      });
+      setBody("");
+      setStance(null);
+      // Let the new exchange settle into view.
+      requestAnimationFrame(() => {
+        feedRef.current?.querySelector(".cd-thread:last-child")?.scrollIntoView({
+          behavior: "smooth",
+          block: "nearest",
+        });
+      });
+    } catch {
+      setError("The corpus could not be reached. Your comment was not saved.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="cd" aria-label="Discussion with the corpus">
+      <div className="cd-head">
+        <span className="cd-mark" aria-hidden="true" />
+        <h2>{heading}</h2>
+      </div>
+      {intro ? <p className="cd-intro">{intro}</p> : null}
+
+      <div className="cd-feed" ref={feedRef}>
+        {loading ? (
+          <p className="cd-empty">Opening the board…</p>
+        ) : threads.length === 0 ? (
+          <p className="cd-empty">
+            No one has spoken yet. Be the first to put a view to the corpus.
+          </p>
+        ) : (
+          threads.map(({ comment, reply }) => (
+            <div className="cd-thread" key={comment.id}>
+              <article className="cd-msg cd-visitor">
+                <header className="cd-byline">
+                  <span className="cd-who">{comment.author_name || "A reader"}</span>
+                  {comment.stance ? (
+                    <span className={`cd-stance cd-stance-${comment.stance}`}>
+                      {STANCE_META[comment.stance].short}
+                    </span>
+                  ) : null}
+                </header>
+                <p className="cd-body">{comment.body}</p>
+              </article>
+
+              {reply ? (
+                <article className="cd-msg cd-corpus">
+                  <header className="cd-byline">
+                    <span className="cd-dot" aria-hidden="true" />
+                    <span className="cd-who">The Corpus</span>
+                  </header>
+                  <div className="cd-body cd-corpus-body">
+                    {reply.body.split(/\n{2,}/).map((para, i) => (
+                      <p key={i}>{para}</p>
+                    ))}
+                  </div>
+                </article>
+              ) : (
+                <p className="cd-silent">The corpus was silent on this one.</p>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+
+      <form className="cd-form" onSubmit={submit}>
+        <div className="cd-stances" role="group" aria-label="Your stance">
+          {(Object.keys(STANCE_META) as Stance[]).map((s) => (
+            <button
+              type="button"
+              key={s}
+              className={`cd-chip${stance === s ? " cd-chip-on" : ""}`}
+              aria-pressed={stance === s}
+              onClick={() => setStance((cur) => (cur === s ? null : s))}
+            >
+              {STANCE_META[s].label}
+            </button>
+          ))}
+        </div>
+
+        <textarea
+          className="cd-text"
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder={placeholder}
+          rows={4}
+          maxLength={4000}
+        />
+
+        <div className="cd-row">
+          <input
+            className="cd-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Name (optional)"
+            maxLength={80}
+          />
+          <button className="cd-submit" type="submit" disabled={submitting || !body.trim()}>
+            {submitting ? "The corpus is considering…" : "Post & ask the corpus"}
+          </button>
+        </div>
+
+        {error ? <p className="cd-error">{error}</p> : null}
+      </form>
+    </section>
+  );
+}

--- a/academy/web/src/content/playground/situations.ts
+++ b/academy/web/src/content/playground/situations.ts
@@ -1,0 +1,119 @@
+/**
+ * The Situations Game.
+ *
+ * Everyday situations people actually face, each paired with the response the
+ * tradition would give — a one-line verdict, the passage it rests on, and the
+ * reasoning. Readers can agree or disagree with the verdict and take it up with
+ * the corpus underneath (thread_key = `situation:<id>`).
+ *
+ * Canon renderings are close paraphrase from public-domain translations and
+ * carry standard references so they can be read against any edition. To add a
+ * situation, append a record; the hub count and the page update automatically.
+ */
+
+export type Situation = {
+  id: string;
+  /** Short domain label, e.g. "At work", "Online", "Family". */
+  tag: string;
+  /** The prompt, phrased as a title. */
+  title: string;
+  /** The everyday scene, in the second person. */
+  scene: string;
+  /** The source the response rests on. */
+  ref: { work: string; text_ref: string };
+  /** The one-line philosophical response. */
+  verdict: string;
+  /** Why the tradition answers this way. */
+  reason: string;
+};
+
+export const situations: Situation[] = [
+  {
+    id: "the-slow-line",
+    tag: "Everyday friction",
+    title: "The line that will not move",
+    scene:
+      "You have six minutes to be somewhere and the checkout has stopped. The person ahead is disputing a coupon, the second register just closed, and you can feel the heat climbing your neck.",
+    ref: { work: "Epictetus", text_ref: "Enchiridion 5" },
+    verdict:
+      "The line is not doing this to you; your verdict about the line is. Drop the verdict and the heat has nothing to burn.",
+    reason:
+      "Men are disturbed not by things but by their judgments about things. The delay is indifferent — it is neither good nor bad in itself. What stings is the added opinion 'this must not be happening to me,' which you supplied and can withdraw. Keep the fact (I will be late), discard the protest against the fact, and act from there.",
+  },
+  {
+    id: "the-stolen-credit",
+    tag: "At work",
+    title: "The colleague who took the credit",
+    scene:
+      "In the meeting your idea comes out of someone else's mouth, the room nods, and their name is now on it. You did the work in the dark for three weeks.",
+    ref: { work: "Epictetus", text_ref: "Enchiridion 1" },
+    verdict:
+      "Your work was up to you and you did it well; the credit was never up to you. Guard the first and hold the second loosely.",
+    reason:
+      "Reputation sits among the things not in our power — it lives in other people's judgments, which you do not govern. What is yours is the quality of the work and how you conduct yourself now: whether you state the record plainly without resentment, or hand your peace to a person who has already shown you they will spend it. The theft is real; the ruin of your evening over it is optional.",
+  },
+  {
+    id: "the-cancelled-flight",
+    tag: "Plans undone",
+    title: "The flight the airline cancelled",
+    scene:
+      "The board flips to CANCELLED. There is no crew, no rebooking until tomorrow, and the thing you were flying for happens tonight without you.",
+    ref: { work: "Epictetus", text_ref: "Enchiridion 8" },
+    verdict:
+      "Do not ask that the flight had not been cancelled. Ask what is now yours to do, and want that.",
+    reason:
+      "Do not seek to have events happen as you wish, but wish them to happen as they do, and your life will go smoothly. Wishing the cancellation undone is a quarrel with a fact already settled, and you always lose that quarrel. The open question — the phone call you make, the night you salvage, the composure you keep — is the only field left where your choice still decides the outcome.",
+  },
+  {
+    id: "the-insult-online",
+    tag: "Online",
+    title: "The stranger who insulted you online",
+    scene:
+      "A reply notification. Someone you have never met has called you, publicly, something contemptuous, and thirty people have liked it. Your thumb is already hovering over the reply box.",
+    ref: { work: "Epictetus", text_ref: "Enchiridion 20" },
+    verdict:
+      "It is not the insult that wounds you but your decision that it is wounding. The reply box is where you hand them the power.",
+    reason:
+      "Remember that what is insulting is not the person who abuses you but your judgment that they are insulting. When you feel provoked, notice that it is your own opinion that has provoked you. The pause before the reply is the whole discipline: in it you can see that a stranger's contempt is their impression, not your worth, and that the like count measures their impressions too — not you.",
+  },
+  {
+    id: "the-friend-who-flaked",
+    tag: "Friendship",
+    title: "The friend who cancelled at the last minute",
+    scene:
+      "Twenty minutes before you were due to meet, the text arrives: something came up, rain check. It is the third time. You had rearranged your day around it.",
+    ref: { work: "Marcus Aurelius", text_ref: "Meditations II.1" },
+    verdict:
+      "You already knew this was possible today; meet it as a known feature of people, not an ambush, and keep your own conduct clean.",
+    reason:
+      "Begin the day telling yourself you will meet the unreliable, the ungrateful, the self-absorbed — and that none of them can implicate you in ugliness or make you hate them, for we were made to work together. The flake is disappointing and you may say so. What is not required is the story that you have been wronged by a monster; the same person you value is the one who does this, and your task is to respond as the friend you mean to be, not to be conscripted into resentment.",
+  },
+  {
+    id: "the-promotion-lost",
+    tag: "At work",
+    title: "The promotion that went to someone else",
+    scene:
+      "The email goes out congratulating them. You were told you were the frontrunner. You can already picture the year ahead in the same seat, doing the same work, passed over.",
+    ref: { work: "Epictetus", text_ref: "Enchiridion 2" },
+    verdict:
+      "You aimed desire at a thing outside your control and it missed. Move desire onto what you can actually secure and you stop being hostage to the committee.",
+    reason:
+      "Desire promises the getting of what you want, but whoever fixes desire on things not in their power is bound to be disappointed. The title was theirs to give, not yours to take — so wanting it as if it were owed sets you up to be crushed by their decision. Redirect the wanting to what is yours: the excellence of your work, your steadiness, the next move you actually control. That desire never returns empty.",
+  },
+  {
+    id: "the-thing-you-cannot-fix",
+    tag: "Family",
+    title: "The parent you cannot fix",
+    scene:
+      "The diagnosis is not going to improve. You have made the calls, moved the money, read everything. And still, at 2 a.m., you lie awake trying to solve a thing that has no solution.",
+    ref: { work: "Epictetus", text_ref: "Enchiridion 1" },
+    verdict:
+      "Sort the situation into what is yours and what is not. Pour yourself into the first without reserve; lay the second down, not because you are cold, but because it was never in your hands.",
+    reason:
+      "Some things are up to us and some are not. Up to us are our judgments and our actions; not up to us are the body, the outcome, the course of a disease. The love, the presence, the care you give are wholly yours and worth everything. The cure is not yours to command, and the night spent demanding it from a power you do not have takes strength from the care that is real. This is not resignation. It is aiming your whole force at the part that will answer to it.",
+  },
+];
+
+export function getSituation(id: string): Situation | undefined {
+  return situations.find((s) => s.id === id);
+}

--- a/academy/web/src/middleware.ts
+++ b/academy/web/src/middleware.ts
@@ -12,8 +12,11 @@ import type { NextRequest } from 'next/server'
 // Railway backend rate-limits the one interactive route (passage).
 //
 // Perspectives (/perspectives/*) is a public essay surface, like the Library.
+// The Playground (/playground/*) is public for the same reason — an open
+// workshop of essays and the situations game — and its discussion API
+// (/api/playground/*) writes only via the service role, server-side.
 const PUBLIC_ROUTES = ['/', '/waitlist', '/login', '/signup', '/library', '/api/oracle', '/api/linkedin-callback', '/api/cron/post-due']
-const PUBLIC_PREFIXES = ['/api/library/', '/api/observatory/', '/perspectives/']
+const PUBLIC_PREFIXES = ['/api/library/', '/api/observatory/', '/perspectives/', '/playground', '/api/playground/']
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl


### PR DESCRIPTION
## Summary

Two related surfaces in `academy/web`:

1. **Perspectives essay — "The Notebook and the Tapes"** (`/perspectives/the-notebook-and-the-tapes`): the paired-document essay on Socratic intellectualism, with its own type system (Fraunces / Newsreader / Plex) and the paper/tape/canon layout.

2. **The Arete AI Playground** (`/playground`): a public workshop for testing ideas against the corpus, built on top of the essay.
   - **Hub** listing experiments.
   - **`/playground/perspectives/[slug]`** — the essay plus a corpus discussion board. Extracts a shared `PerspectiveArticle` component; the original `/perspectives` page now renders through it (output unchanged).
   - **`/playground/situations`** — the Situations Game: 7 seeded everyday situations, each with a philosophical verdict, its reasoning, and the canon passage it rests on.

## The discussion mechanic

Reusable `CorpusDiscussion` component: a visitor posts a comment and optionally takes a stance (agree / disagree / unsure). The corpus answers via the existing Oracle (RAG over the whole corpus), and both the comment and the reply persist to a new `playground_comments` table.

- **RLS**: public `SELECT`; writes go only through the service role server-side, so the browser can never write directly and the corpus reply + daily rate limit stay under server control.
- The Oracle caps `question` at 500 chars (it drives RAG retrieval), so the essay/situation **context + instructions ride in the `history`** field and `question` stays the compact stance + comment.

## Access

Middleware: `/playground` and `/api/playground/` made public, like Perspectives.

## Database

Migration `academy/supabase/migrations/006_playground_comments.sql` — **already applied to the production Supabase project** (`playground_comments` exists live), so no manual migration step is needed on deploy.

## Verification

- `tsc --noEmit` clean · `next build` clean (all routes compile; essay + playground perspective prerendered as SSG)
- Discussion round-trip tested live on dev: visitor comment → corpus reply (real sources: Aristotle, Plato, Adam Smith) → both persisted → threading, stance badges, and the "corpus was silent" fallback render on reload
- Original `/perspectives` page byte-identical after the shared-component refactor
- Test rows deleted; the board starts empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)