### PR TITLE
Situations Game: master–detail layout

### DIFF
--- a/academy/web/src/app/playground/playground.css
+++ b/academy/web/src/app/playground/playground.css
@@ -152,9 +152,162 @@
 
 /* ==================== situations game ==================== */
 .pg-sit {
-  max-width: var(--measure);
+  max-width: 68rem;
   margin: 0 auto;
   padding: 0 var(--gap) clamp(5rem, 12vh, 9rem);
+}
+.pg-sit-h1 {
+  font-family: var(--display);
+  font-variation-settings: 'WONK' 1;
+  font-weight: 400;
+  font-size: clamp(2.2rem, 6vw, 3.4rem);
+  line-height: 1.02;
+  margin: 0;
+  color: var(--paper);
+}
+.pg-sit-note {
+  font-family: var(--util);
+  font-size: 0.82rem;
+  color: var(--bone-dim);
+  line-height: 1.6;
+  border-top: 1px solid var(--tape-rule);
+  padding-top: 1.6rem;
+  margin-top: clamp(2rem, 5vh, 3.5rem);
+}
+
+/* master–detail: a rail of situations, the selected one in the main pane */
+.pg-sit-layout {
+  display: grid;
+  grid-template-columns: minmax(14rem, 17rem) 1fr;
+  gap: clamp(1.2rem, 3vw, 2.4rem);
+  align-items: start;
+}
+.pg-sit-nav {
+  position: sticky;
+  top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  max-height: calc(100vh - 3rem);
+  overflow-y: auto;
+}
+.pg-sit-navitem {
+  display: flex;
+  align-items: baseline;
+  gap: 0.7rem;
+  text-align: left;
+  background: #100e0a;
+  border: 1px solid var(--tape-rule);
+  border-left: 2px solid transparent;
+  padding: 0.7rem 0.85rem;
+  cursor: pointer;
+  color: var(--bone-dim);
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+.pg-sit-navitem:hover {
+  color: var(--bone);
+  border-color: var(--bone-dim);
+}
+.pg-sit-navitem[aria-current='true'] {
+  color: var(--paper);
+  background: var(--slate);
+  border-left-color: var(--pom);
+}
+.pg-sit-navnum {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  color: var(--pom-lit);
+  flex: none;
+}
+.pg-sit-navtext {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+.pg-sit-navtag {
+  font-family: var(--util);
+  font-size: 0.56rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--bone-dim);
+}
+.pg-sit-navitem[aria-current='true'] .pg-sit-navtag {
+  color: var(--pom-lit);
+}
+.pg-sit-navtitle {
+  font-family: var(--util);
+  font-size: 0.9rem;
+  line-height: 1.28;
+}
+.pg-sit-main {
+  min-width: 0;
+}
+.pg-sit-progress {
+  float: right;
+  font-family: var(--mono);
+  letter-spacing: normal;
+  color: var(--bone-dim);
+}
+
+/* prev / next */
+.pg-sit-pager {
+  display: flex;
+  gap: 0.7rem;
+  margin-top: 1.4rem;
+}
+.pg-sit-pagerbtn {
+  flex: 1 1 0;
+  min-width: 0;
+  background: transparent;
+  border: 1px solid var(--tape-rule);
+  color: var(--bone);
+  font-family: var(--util);
+  font-size: 0.8rem;
+  padding: 0.7rem 0.9rem;
+  cursor: pointer;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+.pg-sit-pagerbtn-next {
+  text-align: right;
+}
+.pg-sit-pagerbtn:hover:not(:disabled) {
+  color: var(--paper);
+  border-color: var(--pom);
+}
+.pg-sit-pagerbtn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+@media (max-width: 860px) {
+  .pg-sit-layout {
+    grid-template-columns: 1fr;
+  }
+  .pg-sit-nav {
+    position: static;
+    flex-direction: row;
+    max-height: none;
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+    scroll-snap-type: x proximity;
+  }
+  .pg-sit-navitem {
+    flex: 0 0 auto;
+    width: 13rem;
+    border-left: 1px solid var(--tape-rule);
+    border-top: 2px solid transparent;
+    scroll-snap-align: start;
+  }
+  .pg-sit-navitem[aria-current='true'] {
+    border-left-color: var(--tape-rule);
+    border-top-color: var(--pom);
+  }
 }
 .pg-back {
   display: inline-block;
@@ -182,7 +335,7 @@
 }
 
 .pg-situation {
-  margin: 0 0 clamp(2.5rem, 6vh, 4rem);
+  margin: 0;
   border: 1px solid var(--tape-rule);
   background: #100e0a;
 }

--- a/academy/web/src/app/playground/situations/page.tsx
+++ b/academy/web/src/app/playground/situations/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 import { situations } from "@/content/playground/situations";
-import CorpusDiscussion from "@/components/playground/CorpusDiscussion";
+import SituationsGame from "@/components/playground/SituationsGame";
 
 export const metadata: Metadata = {
   title: "The Situations Game — Playground | Arete Academy",
@@ -22,72 +22,18 @@ export default function SituationsPage() {
           <p className="pg-eyebrow" style={{ marginBottom: "1rem" }}>
             The Situations Game
           </p>
-          <h1
-            style={{
-              fontFamily: "var(--display)",
-              fontVariationSettings: "'WONK' 1",
-              fontWeight: 400,
-              fontSize: "clamp(2.2rem, 6vw, 3.4rem)",
-              lineHeight: 1.02,
-              margin: 0,
-              color: "var(--paper)",
-            }}
-          >
-            What would the school say?
-          </h1>
+          <h1 className="pg-sit-h1">What would the school say?</h1>
           <p>
             Ordinary moments, and the response the tradition would actually give
-            — not a platitude, but the move it would make. Read the verdict, then
-            decide whether you buy it. Agree, disagree, or push back, and the
-            corpus will answer.
+            — not a platitude, but the move it would make. Pick a situation, read
+            the verdict, then decide whether you buy it. Agree, disagree, or push
+            back, and the corpus will answer.
           </p>
         </header>
 
-        {situations.map((s) => (
-          <article className="pg-situation" key={s.id} id={s.id}>
-            <div className="pg-situation-head">
-              <p className="pg-sit-tag">{s.tag}</p>
-              <h2>{s.title}</h2>
-              <p className="pg-sit-scene">{s.scene}</p>
-            </div>
+        <SituationsGame situations={situations} />
 
-            <div className="pg-sit-response">
-              <p className="pg-sit-response-ref">
-                <span className="pg-diamond" aria-hidden="true" />
-                {s.ref.work}
-                <span style={{ opacity: 0.45 }}>/</span>
-                {s.ref.text_ref}
-              </p>
-              <p className="pg-sit-verdict">{s.verdict}</p>
-              <p className="pg-sit-reason">{s.reason}</p>
-            </div>
-
-            <CorpusDiscussion
-              threadKey={`situation:${s.id}`}
-              context={
-                `A situation from the Situations Game — "${s.title}" (${s.tag}). ` +
-                `The scene: ${s.scene} ` +
-                `The tradition's verdict, resting on ${s.ref.work} ${s.ref.text_ref}: ` +
-                `"${s.verdict}" Reasoning: ${s.reason} ` +
-                `The reader is agreeing or disagreeing with this verdict.`
-              }
-              heading="Do you buy the verdict?"
-              placeholder="Agree, disagree, or complicate it — the corpus will answer."
-            />
-          </article>
-        ))}
-
-        <p
-          style={{
-            fontFamily: "var(--util)",
-            fontSize: "0.82rem",
-            color: "var(--bone-dim)",
-            lineHeight: 1.6,
-            borderTop: "1px solid var(--tape-rule)",
-            paddingTop: "1.6rem",
-            marginTop: "1rem",
-          }}
-        >
+        <p className="pg-sit-note">
           Canon renderings are close paraphrase from public-domain translations
           and carry standard references so they can be read against any edition.
         </p>

--- a/academy/web/src/components/playground/SituationsGame.tsx
+++ b/academy/web/src/components/playground/SituationsGame.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { Situation } from "@/content/playground/situations";
+import CorpusDiscussion from "@/components/playground/CorpusDiscussion";
+
+/**
+ * The Situations Game as a master–detail view: a rail of situations on the
+ * left, the selected one (verdict, reasoning, canon, and its own corpus
+ * discussion) in the main pane. Replaces the long single scroll.
+ *
+ * The selection lives in the URL hash (#<id>) so a situation can be linked to
+ * directly and the back/forward buttons move between them.
+ */
+export default function SituationsGame({ situations }: { situations: Situation[] }) {
+  const [activeId, setActiveId] = useState<string>(situations[0]?.id ?? "");
+  const mainRef = useRef<HTMLDivElement>(null);
+  const didMount = useRef(false);
+
+  // Adopt an initial selection from the hash, and follow hash changes (back/fwd).
+  useEffect(() => {
+    const fromHash = () => {
+      const id = decodeURIComponent(window.location.hash.replace(/^#/, ""));
+      if (id && situations.some((s) => s.id === id)) setActiveId(id);
+    };
+    fromHash();
+    window.addEventListener("hashchange", fromHash);
+    return () => window.removeEventListener("hashchange", fromHash);
+  }, [situations]);
+
+  function select(id: string) {
+    setActiveId(id);
+    if (window.location.hash !== `#${id}`) {
+      history.pushState(null, "", `#${id}`);
+    }
+    // On narrow screens the rail sits above the pane — bring the detail into view.
+    if (window.matchMedia("(max-width: 860px)").matches) {
+      requestAnimationFrame(() =>
+        mainRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })
+      );
+    }
+  }
+
+  const activeIndex = Math.max(
+    0,
+    situations.findIndex((s) => s.id === activeId)
+  );
+  const s = situations[activeIndex];
+
+  // Reset the pane scroll when the situation changes (after the first render).
+  useEffect(() => {
+    if (didMount.current) {
+      mainRef.current?.scrollTo?.({ top: 0 });
+    } else {
+      didMount.current = true;
+    }
+  }, [activeId]);
+
+  if (!s) return null;
+
+  const prev = situations[activeIndex - 1];
+  const next = situations[activeIndex + 1];
+
+  return (
+    <div className="pg-sit-layout">
+      <nav className="pg-sit-nav" aria-label="Situations">
+        {situations.map((item, i) => (
+          <button
+            key={item.id}
+            type="button"
+            className="pg-sit-navitem"
+            aria-current={item.id === activeId}
+            onClick={() => select(item.id)}
+          >
+            <span className="pg-sit-navnum">{String(i + 1).padStart(2, "0")}</span>
+            <span className="pg-sit-navtext">
+              <span className="pg-sit-navtag">{item.tag}</span>
+              <span className="pg-sit-navtitle">{item.title}</span>
+            </span>
+          </button>
+        ))}
+      </nav>
+
+      <div className="pg-sit-main" ref={mainRef}>
+        <article className="pg-situation" key={s.id} id={s.id}>
+          <div className="pg-situation-head">
+            <p className="pg-sit-tag">
+              {s.tag}
+              <span className="pg-sit-progress">
+                {activeIndex + 1} / {situations.length}
+              </span>
+            </p>
+            <h2>{s.title}</h2>
+            <p className="pg-sit-scene">{s.scene}</p>
+          </div>
+
+          <div className="pg-sit-response">
+            <p className="pg-sit-response-ref">
+              <span className="pg-diamond" aria-hidden="true" />
+              {s.ref.work}
+              <span style={{ opacity: 0.45 }}>/</span>
+              {s.ref.text_ref}
+            </p>
+            <p className="pg-sit-verdict">{s.verdict}</p>
+            <p className="pg-sit-reason">{s.reason}</p>
+          </div>
+
+          {/* key forces a fresh thread load when switching situations */}
+          <CorpusDiscussion
+            key={s.id}
+            threadKey={`situation:${s.id}`}
+            context={
+              `A situation from the Situations Game — "${s.title}" (${s.tag}). ` +
+              `The scene: ${s.scene} ` +
+              `The tradition's verdict, resting on ${s.ref.work} ${s.ref.text_ref}: ` +
+              `"${s.verdict}" Reasoning: ${s.reason} ` +
+              `The reader is agreeing or disagreeing with this verdict.`
+            }
+            heading="Do you buy the verdict?"
+            placeholder="Agree, disagree, or complicate it — the corpus will answer."
+          />
+        </article>
+
+        <div className="pg-sit-pager">
+          <button
+            type="button"
+            className="pg-sit-pagerbtn"
+            disabled={!prev}
+            onClick={() => prev && select(prev.id)}
+          >
+            ← {prev ? prev.title : "Start"}
+          </button>
+          <button
+            type="button"
+            className="pg-sit-pagerbtn pg-sit-pagerbtn-next"
+            disabled={!next}
+            onClick={() => next && select(next.id)}
+          >
+            {next ? next.title : "End"} →
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Reworks the Situations Game (`/playground/situations`) from a long single scroll into a **master–detail** view — a sticky rail of situations on the left, the selected one (scene, verdict, reasoning, canon ref, and its corpus discussion) in the main pane.

## Details

- New client component `SituationsGame` holds the selection; the page stays a server component (keeps `metadata`).
- **URL-hash deep-linking** (`#<id>`) — situations are linkable, and browser back/forward move between them.
- **Prev / Next** pager labeled with the neighboring situations + an "n / N" progress marker.
- `CorpusDiscussion` re-mounts per situation (`key={id}`) so each thread loads its own comments.
- **Mobile** (≤860px): the rail collapses to a horizontal snap-scroll strip above the pane; selecting scrolls the detail into view; no horizontal page overflow.

## Verification

- `next build` clean.
- Dev-verified: two-column sticky layout, selection swaps the pane + updates hash/progress, deep-linking opens the right situation, mobile reflow, no console errors.

Scales for the larger situations list to come — the rail is the natural home for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)